### PR TITLE
fix: restore injected wallet options

### DIFF
--- a/src/components/providers/BrowserWagmiProvider.tsx
+++ b/src/components/providers/BrowserWagmiProvider.tsx
@@ -1,10 +1,23 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { RainbowKitProvider, getDefaultConfig } from "@rainbow-me/rainbowkit";
+import {
+  RainbowKitProvider,
+  getDefaultConfig,
+  type Wallet,
+} from "@rainbow-me/rainbowkit";
+import {
+  baseAccount,
+  injectedWallet,
+  metaMaskWallet,
+  rainbowWallet,
+  safeWallet,
+  walletConnectWallet,
+} from "@rainbow-me/rainbowkit/wallets";
 import React from "react";
-import { WagmiProvider } from "wagmi";
+import { WagmiProvider, createConnector } from "wagmi";
 import { base } from "wagmi/chains";
+import { injected } from "wagmi/connectors";
 import { MiniAppContext } from "../../contexts/MiniAppContext";
 import { baseTransport } from "../../lib/wagmiConfig";
 
@@ -19,11 +32,41 @@ if (!process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID) {
   );
 }
 
+const coinbaseInjectedWallet = (): Wallet => ({
+  id: "coinbaseInjected",
+  name: "Coinbase Wallet",
+  shortName: "Coinbase",
+  rdns: "com.coinbase.wallet",
+  iconUrl:
+    "data:image/svg+xml,%3Csvg%20width%3D%2228%22%20height%3D%2228%22%20viewBox%3D%220%200%2028%2028%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Crect%20width%3D%2228%22%20height%3D%2228%22%20fill%3D%22%232C5FF6%22%2F%3E%3Cpath%20fill-rule%3D%22evenodd%22%20clip-rule%3D%22evenodd%22%20d%3D%22M14%2023.8C19.4124%2023.8%2023.8%2019.4124%2023.8%2014C23.8%208.58761%2019.4124%204.2%2014%204.2C8.58761%204.2%204.2%208.58761%204.2%2014C4.2%2019.4124%208.58761%2023.8%2014%2023.8ZM11.55%2010.8C11.1358%2010.8%2010.8%2011.1358%2010.8%2011.55V16.45C10.8%2016.8642%2011.1358%2017.2%2011.55%2017.2H16.45C16.8642%2017.2%2017.2%2016.8642%2017.2%2016.45V11.55C17.2%2011.1358%2016.8642%2010.8%2016.45%2010.8H11.55Z%22%20fill%3D%22white%22%2F%3E%3C%2Fsvg%3E",
+  iconAccent: "#2c5ff6",
+  iconBackground: "#2c5ff6",
+  createConnector: (walletDetails) =>
+    createConnector((config) => ({
+      ...injected({ target: "coinbaseWallet" })(config),
+      ...walletDetails,
+    })),
+});
+
 // Browser specific wagmi config using RainbowKit connectors
 export const browserConfig = getDefaultConfig({
   appName: "Streme Fun",
   projectId: walletConnectProjectId,
   chains: [base],
+  wallets: [
+    {
+      groupName: "Popular",
+      wallets: [
+        safeWallet,
+        coinbaseInjectedWallet,
+        injectedWallet,
+        rainbowWallet,
+        baseAccount,
+        metaMaskWallet,
+        walletConnectWallet,
+      ],
+    },
+  ],
   transports: {
     [base.id]: baseTransport,
   },


### PR DESCRIPTION
## Summary

Browser wallet users can connect through the active injected provider again, including Coinbase/Base App browsers. RainbowKit's upgraded default wallet list only surfaced Base Account, WalletConnect-backed wallets, and Safe; the browser wagmi config now defines the wallet list explicitly and adds a Coinbase Wallet connector backed by wagmi's injected Coinbase target plus the generic Browser Wallet fallback.

## Test Plan

- Connector harness confirms Coinbase Wallet is `type: injected` with connector id `coinbaseWallet`, and Browser Wallet is also present.
- `npm run typecheck`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)