### PR TITLE
feat: pulse growth engine, yield flex cards, agent-native gateway

### DIFF
--- a/__tests__/lib/agent/txBuilders.test.ts
+++ b/__tests__/lib/agent/txBuilders.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "@jest/globals";
+import { decodeFunctionData, parseAbi, parseEther } from "viem";
+import {
+  AgentInputError,
+  BASE_CHAIN_ID,
+  STAKING_HELPER,
+  buildBuyTx,
+  buildConnectPoolTx,
+  buildStakeTx,
+  buildStreamTx,
+  buildUnstakeTx,
+} from "@/src/lib/agent/txBuilders";
+
+const TOKEN = "0x3b3cd21242ba44e9865b066e5ef5d1cc1030cc58";
+const STAKING = "0x93419f1c0f73b278c73085c17407794a6580deff";
+const POOL = "0xa040a8564c433970d7919c441104b1d25b9eaa1c";
+const WALLET = "0x09a900eb2ff6e9aca12d4d1a396ddc9be0307661";
+
+describe("buildStakeTx", () => {
+  it("encodes an ERC777 send to the StakingHelper", () => {
+    const built = buildStakeTx({ tokenAddress: TOKEN, amount: "1000" });
+
+    expect(built.tx.to).toBe(TOKEN);
+    expect(built.tx.chainId).toBe(BASE_CHAIN_ID);
+    expect(built.tx.value).toBeUndefined();
+
+    const decoded = decodeFunctionData({
+      abi: parseAbi([
+        "function send(address recipient, uint256 amount, bytes userData)",
+      ]),
+      data: built.tx.data,
+    });
+    expect(decoded.functionName).toBe("send");
+    expect((decoded.args[0] as string).toLowerCase()).toBe(
+      STAKING_HELPER.toLowerCase()
+    );
+    expect(decoded.args[1]).toBe(parseEther("1000"));
+    expect(decoded.args[2]).toBe("0x");
+  });
+
+  it("rejects bad addresses and amounts", () => {
+    expect(() =>
+      buildStakeTx({ tokenAddress: "not-an-address", amount: "1" })
+    ).toThrow(AgentInputError);
+    expect(() =>
+      buildStakeTx({ tokenAddress: TOKEN, amount: "0" })
+    ).toThrow(AgentInputError);
+    expect(() =>
+      buildStakeTx({ tokenAddress: TOKEN, amount: "lots" })
+    ).toThrow(AgentInputError);
+  });
+});
+
+describe("buildUnstakeTx", () => {
+  it("encodes unstake(to, amount) on the staking contract", () => {
+    const built = buildUnstakeTx({
+      stakingAddress: STAKING,
+      to: WALLET,
+      amount: "50.5",
+    });
+
+    expect(built.tx.to).toBe(STAKING);
+    const decoded = decodeFunctionData({
+      abi: parseAbi(["function unstake(address to, uint256 amount)"]),
+      data: built.tx.data,
+    });
+    expect((decoded.args[0] as string).toLowerCase()).toBe(WALLET);
+    expect(decoded.args[1]).toBe(parseEther("50.5"));
+  });
+});
+
+describe("buildConnectPoolTx", () => {
+  it("targets the GDA forwarder with the pool address", () => {
+    const built = buildConnectPoolTx({ poolAddress: POOL });
+    expect(built.tx.to).toBe("0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08");
+
+    const decoded = decodeFunctionData({
+      abi: parseAbi([
+        "function connectPool(address pool, bytes userData) returns (bool)",
+      ]),
+      data: built.tx.data,
+    });
+    expect((decoded.args[0] as string).toLowerCase()).toBe(POOL);
+  });
+});
+
+describe("buildStreamTx", () => {
+  const STREAM_ABI = parseAbi([
+    "function setFlowrate(address token, address receiver, int96 flowrate) returns (bool)",
+  ]);
+
+  it("converts tokens/day to wei/second", () => {
+    const built = buildStreamTx({
+      tokenAddress: TOKEN,
+      receiver: WALLET,
+      tokensPerDay: "86400",
+    });
+
+    const decoded = decodeFunctionData({
+      abi: STREAM_ABI,
+      data: built.tx.data,
+    });
+    // 86400 tokens/day = 1 token/second = 1e18 wei/second
+    expect(decoded.args[2]).toBe(10n ** 18n);
+  });
+
+  it("stops the stream at zero", () => {
+    const built = buildStreamTx({
+      tokenAddress: TOKEN,
+      receiver: WALLET,
+      tokensPerDay: "0",
+    });
+    const decoded = decodeFunctionData({
+      abi: STREAM_ABI,
+      data: built.tx.data,
+    });
+    expect(decoded.args[2]).toBe(0n);
+    expect(built.description).toContain("Stop");
+  });
+});
+
+describe("buildBuyTx", () => {
+  it("encodes a zap with slippage from the injected quote", async () => {
+    const built = await buildBuyTx({
+      tokenAddress: TOKEN,
+      ethAmount: "0.01",
+      quotedAmountOut: 1_000_000n * 10n ** 18n,
+      slippageBps: 100, // 1%
+    });
+
+    expect(built.tx.value).toBe(`0x${parseEther("0.01").toString(16)}`);
+    expect(built.tx.chainId).toBe(BASE_CHAIN_ID);
+
+    const decoded = decodeFunctionData({
+      abi: parseAbi([
+        "function zap(address tokenOut, uint256 amountIn, uint256 amountOutMin, address stakingContract) payable returns (uint256)",
+      ]),
+      data: built.tx.data,
+    });
+    expect((decoded.args[0] as string).toLowerCase()).toBe(TOKEN);
+    expect(decoded.args[1]).toBe(parseEther("0.01"));
+    // 1% slippage off 1M tokens
+    expect(decoded.args[2]).toBe(990_000n * 10n ** 18n);
+    // no stake → zero staking contract
+    expect(decoded.args[3]).toBe("0x0000000000000000000000000000000000000000");
+  });
+
+  it("passes the staking contract when stake=true", async () => {
+    const built = await buildBuyTx({
+      tokenAddress: TOKEN,
+      ethAmount: "0.01",
+      stake: true,
+      stakingAddress: STAKING,
+      quotedAmountOut: 10n ** 18n,
+    });
+    const decoded = decodeFunctionData({
+      abi: parseAbi([
+        "function zap(address tokenOut, uint256 amountIn, uint256 amountOutMin, address stakingContract) payable returns (uint256)",
+      ]),
+      data: built.tx.data,
+    });
+    expect((decoded.args[3] as string).toLowerCase()).toBe(STAKING);
+  });
+
+  it("requires a staking address when stake=true", async () => {
+    await expect(
+      buildBuyTx({
+        tokenAddress: TOKEN,
+        ethAmount: "0.01",
+        stake: true,
+        quotedAmountOut: 10n ** 18n,
+      })
+    ).rejects.toThrow(AgentInputError);
+  });
+
+  it("rejects out-of-range slippage", async () => {
+    await expect(
+      buildBuyTx({
+        tokenAddress: TOKEN,
+        ethAmount: "0.01",
+        slippageBps: 10_000,
+        quotedAmountOut: 10n ** 18n,
+      })
+    ).rejects.toThrow(AgentInputError);
+  });
+});

--- a/__tests__/lib/pulse/ai.test.ts
+++ b/__tests__/lib/pulse/ai.test.ts
@@ -1,0 +1,88 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+import {
+  aiCopyEnabled,
+  extractProtectedTokens,
+  polishCastDraft,
+  validateRewrite,
+} from "@/src/lib/pulse/ai";
+import type { CastDraft } from "@/src/lib/pulse/types";
+
+const ENV_KEYS = ["PULSE_AI_COPY", "ANTHROPIC_API_KEY"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe("extractProtectedTokens", () => {
+  it("finds tickers, dollar figures, percents, and mentions", () => {
+    const tokens = extractProtectedTokens(
+      "🌊 $TEST by @alice just crossed $1M market cap, +18% today on $12.4k volume"
+    );
+    expect(tokens).toEqual(
+      expect.arrayContaining(["$TEST", "@alice", "$1M", "+18%", "$12.4k"])
+    );
+  });
+});
+
+describe("validateRewrite", () => {
+  const original = "$TEST by @alice crossed $1M market cap · +18% 24h";
+
+  it("accepts a rewrite that preserves every protected token", () => {
+    expect(
+      validateRewrite(
+        original,
+        "the stream got bigger: $TEST (h/t @alice) just hit $1M market cap, up +18% today"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a rewrite that drops or alters a number", () => {
+    expect(
+      validateRewrite(original, "$TEST by @alice crossed $2M market cap")
+    ).toBe(false);
+    expect(validateRewrite(original, "")).toBe(false);
+  });
+
+  it("rejects oversized rewrites", () => {
+    expect(validateRewrite(original, original + "x".repeat(2000))).toBe(false);
+  });
+});
+
+describe("polishCastDraft", () => {
+  const draft: CastDraft = {
+    kind: "milestone",
+    idem: "test",
+    text: "$TEST crossed $1M market cap",
+    embedUrl: "https://streme.fun/token/0xabc",
+  };
+
+  it("is disabled by default and returns the draft untouched", async () => {
+    expect(aiCopyEnabled()).toBe(false);
+    const result = await polishCastDraft(draft);
+    expect(result).toBe(draft);
+  });
+
+  it("requires both the flag and an API key", () => {
+    process.env.PULSE_AI_COPY = "true";
+    expect(aiCopyEnabled()).toBe(false);
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    expect(aiCopyEnabled()).toBe(true);
+  });
+});

--- a/__tests__/lib/pulse/casts.test.ts
+++ b/__tests__/lib/pulse/casts.test.ts
@@ -1,0 +1,249 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import {
+  buildDailyPulseCast,
+  buildMilestoneCast,
+  liveCastingEnabled,
+  publishCast,
+  trimToBytes,
+} from "@/src/lib/pulse/casts";
+import type {
+  Milestone,
+  PulseSnapshot,
+  PulseToken,
+} from "@/src/lib/pulse/types";
+
+const NOW = 1_780_000_000;
+
+function pulseToken(overrides: Partial<PulseToken> = {}): PulseToken {
+  return {
+    address: "0xabc0000000000000000000000000000000000001",
+    name: "Test Token",
+    symbol: "TEST",
+    img_url: null,
+    createdAt: NOW - 86400,
+    lastTradedAt: NOW - 600,
+    marketCap: 250_000,
+    price: 0.0001,
+    volume24h: 12_400,
+    change1h: 2,
+    change24h: 18,
+    totalStakers: 234,
+    rank: 1,
+    score: 80,
+    reasons: [],
+    ...overrides,
+  };
+}
+
+function snapshot(tokens: PulseToken[]): PulseSnapshot {
+  return {
+    generatedAt: NOW,
+    tokens,
+    totals: {
+      trackedTokens: tokens.length,
+      activeTokens24h: tokens.length,
+      volume24h: tokens.reduce((s, t) => s + t.volume24h, 0),
+      marketCap: tokens.reduce((s, t) => s + t.marketCap, 0),
+      launches7d: 0,
+    },
+  };
+}
+
+const milestone: Milestone = {
+  id: "market_cap:0xabc0000000000000000000000000000000000001:1000000",
+  type: "market_cap",
+  tokenAddress: "0xabc0000000000000000000000000000000000001",
+  symbol: "TEST",
+  name: "Test Token",
+  threshold: 1_000_000,
+  value: 1_150_000,
+  detectedAt: NOW,
+};
+
+const PULSE_ENV_KEYS = [
+  "PULSE_CASTS_ENABLED",
+  "NEYNAR_API_KEY",
+  "STREME_SIGNER_UUID",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of PULSE_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  // jest.setup.js installs global.fetch as a shared jest.fn; clear its
+  // accumulated call history so per-test spies start clean.
+  (global.fetch as jest.Mock).mockReset();
+});
+
+function mockFetchResponse(status: number, body: unknown) {
+  return jest.spyOn(global, "fetch").mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+afterEach(() => {
+  for (const key of PULSE_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  jest.restoreAllMocks();
+});
+
+describe("buildDailyPulseCast", () => {
+  it("includes top tokens with stats and stays within the cast limit", () => {
+    const draft = buildDailyPulseCast(
+      snapshot([
+        pulseToken({ symbol: "AAA", volume24h: 50_000 }),
+        pulseToken({ address: "0x02", symbol: "BBB", volume24h: 20_000 }),
+        pulseToken({ address: "0x03", symbol: "CCC", volume24h: 10_000 }),
+        pulseToken({ address: "0x04", symbol: "DDD", volume24h: 5_000 }),
+      ]),
+      "2026-06-10"
+    );
+
+    expect(draft).not.toBeNull();
+    expect(draft!.text).toContain("$AAA");
+    expect(draft!.text).toContain("$BBB");
+    expect(draft!.text).toContain("$CCC");
+    expect(draft!.text).not.toContain("$DDD"); // top 3 only
+    expect(draft!.idem).toBe("daily_pulse:2026-06-10");
+    expect(draft!.embedUrl).toContain("/pulse");
+    expect(new TextEncoder().encode(draft!.text).length).toBeLessThanOrEqual(
+      1024
+    );
+  });
+
+  it("returns null when activity is below the quality gate", () => {
+    const draft = buildDailyPulseCast(
+      snapshot([pulseToken({ volume24h: 40 })]),
+      "2026-06-10"
+    );
+    expect(draft).toBeNull();
+  });
+});
+
+describe("buildMilestoneCast", () => {
+  it("celebrates the crossing and embeds the token page", () => {
+    const draft = buildMilestoneCast(milestone);
+    expect(draft.text).toContain("$TEST");
+    expect(draft.text).toContain("$1M");
+    expect(draft.idem).toBe(milestone.id);
+    expect(draft.embedUrl).toContain(`/token/${milestone.tokenAddress}`);
+  });
+
+  it("@mentions the creator when their username is known", () => {
+    const draft = buildMilestoneCast({
+      ...milestone,
+      creatorUsername: "alice",
+    });
+    expect(draft.text).toContain("$TEST by @alice just crossed");
+  });
+
+  it("omits the byline when the creator is unknown", () => {
+    const draft = buildMilestoneCast(milestone);
+    expect(draft.text).not.toContain(" by @");
+  });
+});
+
+describe("publishCast", () => {
+  it("dry-runs without network calls when live casting is disabled", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    const record = await publishCast(buildMilestoneCast(milestone), {
+      now: NOW,
+    });
+
+    expect(liveCastingEnabled()).toBe(false);
+    expect(record.status).toBe("dry_run");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("publishes via Neynar when fully configured", async () => {
+    process.env.PULSE_CASTS_ENABLED = "true";
+    process.env.NEYNAR_API_KEY = "test-key";
+    process.env.STREME_SIGNER_UUID = "test-signer";
+
+    const fetchSpy = mockFetchResponse(200, { cast: { hash: "0xcast" } });
+
+    const record = await publishCast(buildMilestoneCast(milestone), {
+      now: NOW,
+    });
+
+    expect(record.status).toBe("published");
+    expect(record.castHash).toBe("0xcast");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.neynar.com/v2/farcaster/cast",
+      expect.objectContaining({ method: "POST" })
+    );
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(body.signer_uuid).toBe("test-signer");
+    expect(body.embeds).toEqual([
+      { url: expect.stringContaining("/token/") },
+    ]);
+  });
+
+  it("records a failure instead of throwing on API errors", async () => {
+    process.env.PULSE_CASTS_ENABLED = "true";
+    process.env.NEYNAR_API_KEY = "test-key";
+    process.env.STREME_SIGNER_UUID = "test-signer";
+
+    mockFetchResponse(429, "rate limited");
+
+    const record = await publishCast(buildMilestoneCast(milestone), {
+      now: NOW,
+    });
+    expect(record.status).toBe("failed");
+    expect(record.error).toContain("429");
+  });
+
+  it("honors forceDryRun even when fully configured", async () => {
+    process.env.PULSE_CASTS_ENABLED = "true";
+    process.env.NEYNAR_API_KEY = "test-key";
+    process.env.STREME_SIGNER_UUID = "test-signer";
+
+    const fetchSpy = jest.spyOn(global, "fetch");
+    const record = await publishCast(buildMilestoneCast(milestone), {
+      now: NOW,
+      forceDryRun: true,
+    });
+
+    expect(record.status).toBe("dry_run");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("trimToBytes", () => {
+  it("leaves short text untouched", () => {
+    expect(trimToBytes("hello", 1024)).toBe("hello");
+  });
+
+  it("trims long text to the byte budget with an ellipsis", () => {
+    const long = "a".repeat(2000);
+    const trimmed = trimToBytes(long, 100);
+    expect(new TextEncoder().encode(trimmed).length).toBeLessThanOrEqual(100);
+    expect(trimmed.endsWith("…")).toBe(true);
+  });
+
+  it("does not split multi-byte characters", () => {
+    const emoji = "🌊".repeat(100);
+    const trimmed = trimToBytes(emoji, 50);
+    expect(new TextEncoder().encode(trimmed).length).toBeLessThanOrEqual(50);
+    // Decoding round-trip proves we didn't cut a codepoint in half
+    expect(trimmed).toBe(
+      new TextDecoder().decode(new TextEncoder().encode(trimmed))
+    );
+  });
+});

--- a/__tests__/lib/pulse/milestones.test.ts
+++ b/__tests__/lib/pulse/milestones.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  detectMarketCapMilestones,
+  highestCrossedThreshold,
+  seedAnnouncedState,
+} from "@/src/lib/pulse/milestones";
+import type { PulseTokenMetrics } from "@/src/lib/pulse/types";
+
+const NOW = 1_780_000_000;
+
+function metrics(
+  overrides: Partial<PulseTokenMetrics> = {}
+): PulseTokenMetrics {
+  return {
+    address: "0xabc0000000000000000000000000000000000001",
+    name: "Test Token",
+    symbol: "TEST",
+    img_url: null,
+    createdAt: NOW - 86400,
+    lastTradedAt: NOW - 3600,
+    marketCap: 0,
+    price: 0,
+    volume24h: 1000,
+    change1h: 0,
+    change24h: 0,
+    ...overrides,
+  };
+}
+
+describe("highestCrossedThreshold", () => {
+  it("returns 0 below the lowest threshold", () => {
+    expect(highestCrossedThreshold(49_999)).toBe(0);
+  });
+
+  it("returns the highest crossed level", () => {
+    expect(highestCrossedThreshold(50_000)).toBe(50_000);
+    expect(highestCrossedThreshold(999_999)).toBe(500_000);
+    expect(highestCrossedThreshold(123_000_000)).toBe(100_000_000);
+  });
+});
+
+describe("detectMarketCapMilestones", () => {
+  it("detects a first crossing", () => {
+    const found = detectMarketCapMilestones(
+      [metrics({ marketCap: 120_000 })],
+      {},
+      NOW
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].threshold).toBe(100_000);
+    expect(found[0].id).toBe(
+      "market_cap:0xabc0000000000000000000000000000000000001:100000"
+    );
+  });
+
+  it("does not re-announce a level that was already announced", () => {
+    const announced = {
+      "0xabc0000000000000000000000000000000000001": 100_000,
+    };
+    const found = detectMarketCapMilestones(
+      [metrics({ marketCap: 120_000 })],
+      announced,
+      NOW
+    );
+    expect(found).toHaveLength(0);
+  });
+
+  it("announces only the highest newly crossed level per token", () => {
+    const announced = {
+      "0xabc0000000000000000000000000000000000001": 50_000,
+    };
+    const found = detectMarketCapMilestones(
+      [metrics({ marketCap: 600_000 })],
+      announced,
+      NOW
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].threshold).toBe(500_000);
+  });
+
+  it("ignores crossings on tokens that have not traded recently", () => {
+    const found = detectMarketCapMilestones(
+      [metrics({ marketCap: 120_000, lastTradedAt: NOW - 3 * 86400 })],
+      {},
+      NOW
+    );
+    expect(found).toHaveLength(0);
+  });
+
+  it("sorts multiple milestones by threshold descending", () => {
+    const found = detectMarketCapMilestones(
+      [
+        metrics({ address: "0x01", symbol: "SMALL", marketCap: 60_000 }),
+        metrics({ address: "0x02", symbol: "BIG", marketCap: 2_000_000 }),
+      ],
+      {},
+      NOW
+    );
+    expect(found.map((m) => m.symbol)).toEqual(["BIG", "SMALL"]);
+  });
+});
+
+describe("seedAnnouncedState", () => {
+  it("records current levels without emitting milestones", () => {
+    const seeded = seedAnnouncedState([
+      metrics({ address: "0x01", marketCap: 120_000 }),
+      metrics({ address: "0x02", marketCap: 10 }),
+    ]);
+    expect(seeded).toEqual({ "0x01": 100_000 });
+  });
+});

--- a/__tests__/lib/pulse/notifications.test.ts
+++ b/__tests__/lib/pulse/notifications.test.ts
@@ -1,0 +1,164 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import {
+  buildMilestoneNotification,
+  notifyMilestoneHolders,
+} from "@/src/lib/pulse/notifications";
+import type { Milestone } from "@/src/lib/pulse/types";
+
+const NOW = 1_780_000_000;
+
+const milestone: Milestone = {
+  id: "market_cap:0xabc0000000000000000000000000000000000001:100000",
+  type: "market_cap",
+  tokenAddress: "0xabc0000000000000000000000000000000000001",
+  symbol: "TEST",
+  name: "Test Token",
+  creatorUsername: "alice",
+  threshold: 100_000,
+  value: 120_000,
+  detectedAt: NOW,
+};
+
+const ENV_KEYS = [
+  "PULSE_NOTIFICATIONS_ENABLED",
+  "NEYNAR_API_KEY",
+  "NEYNAR_CLIENT_ID",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  (global.fetch as jest.Mock).mockReset();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  jest.restoreAllMocks();
+});
+
+function holdersResponse(holders: unknown[]) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => holders,
+    text: async () => JSON.stringify(holders),
+  } as unknown as Response;
+}
+
+describe("buildMilestoneNotification", () => {
+  it("includes the symbol, threshold, and token deep link", () => {
+    const n = buildMilestoneNotification(milestone);
+    expect(n.title).toBe("$TEST crossed $100k");
+    expect(n.body).toContain("$100k market cap");
+    expect(n.targetUrl).toContain(`/token/${milestone.tokenAddress}`);
+  });
+});
+
+describe("notifyMilestoneHolders", () => {
+  const holders = [
+    { hasFarcaster: true, farcaster: { fid: 1 } },
+    { hasFarcaster: true, farcaster: { fid: 2 } },
+    { hasFarcaster: false },
+    { hasFarcaster: true, farcaster: { fid: 1 } }, // duplicate fid
+  ];
+
+  it("dry-runs with the real target count when sending is disabled", async () => {
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(holdersResponse(holders));
+
+    const record = await notifyMilestoneHolders(milestone, { now: NOW });
+
+    expect(record.status).toBe("dry_run");
+    expect(record.targetCount).toBe(2); // deduped, farcaster-only
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // holders fetch only, no send
+  });
+
+  it("skips when the token has no Farcaster holders", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(holdersResponse([{ hasFarcaster: false }]));
+
+    const record = await notifyMilestoneHolders(milestone, { now: NOW });
+    expect(record.status).toBe("skipped");
+    expect(record.targetCount).toBe(0);
+  });
+
+  it("records a failure when the holders API errors", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => "boom",
+    } as unknown as Response);
+
+    const record = await notifyMilestoneHolders(milestone, { now: NOW });
+    expect(record.status).toBe("failed");
+    expect(record.error).toContain("500");
+  });
+
+  it("sends via Neynar when fully configured", async () => {
+    process.env.PULSE_NOTIFICATIONS_ENABLED = "true";
+    process.env.NEYNAR_API_KEY = "test-key";
+    process.env.NEYNAR_CLIENT_ID = "test-client";
+
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation(async (url) => {
+        if (String(url).includes("api.streme.fun")) {
+          return holdersResponse(holders);
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => "{}",
+        } as unknown as Response;
+      });
+
+    const record = await notifyMilestoneHolders(milestone, { now: NOW });
+
+    expect(record.status).toBe("sent");
+    expect(record.mode).toBe("neynar");
+    expect(record.targetCount).toBe(2);
+
+    const neynarCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("api.neynar.com")
+    );
+    expect(neynarCall).toBeDefined();
+    const body = JSON.parse((neynarCall![1] as RequestInit).body as string);
+    expect(body.target_fids).toEqual([1, 2]);
+    expect(body.notification.target_url).toContain("/token/");
+  });
+
+  it("honors forceDryRun even when fully configured", async () => {
+    process.env.PULSE_NOTIFICATIONS_ENABLED = "true";
+    process.env.NEYNAR_API_KEY = "test-key";
+    process.env.NEYNAR_CLIENT_ID = "test-client";
+
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(holdersResponse(holders));
+
+    const record = await notifyMilestoneHolders(milestone, {
+      now: NOW,
+      forceDryRun: true,
+    });
+
+    expect(record.status).toBe("dry_run");
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // holders fetch only
+  });
+});

--- a/__tests__/lib/pulse/score.test.ts
+++ b/__tests__/lib/pulse/score.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "@jest/globals";
+import { rankTokens, scoreToken } from "@/src/lib/pulse/score";
+import type { PulseTokenMetrics } from "@/src/lib/pulse/types";
+
+const NOW = 1_780_000_000;
+
+function metrics(overrides: Partial<PulseTokenMetrics> = {}): PulseTokenMetrics {
+  return {
+    address: "0xabc0000000000000000000000000000000000001",
+    name: "Test Token",
+    symbol: "TEST",
+    img_url: null,
+    createdAt: NOW - 30 * 86400,
+    lastTradedAt: 0,
+    marketCap: 0,
+    price: 0,
+    volume24h: 0,
+    change1h: 0,
+    change24h: 0,
+    ...overrides,
+  };
+}
+
+describe("scoreToken", () => {
+  it("scores an active token above a dead one", () => {
+    const active = scoreToken(
+      metrics({
+        volume24h: 50_000,
+        change24h: 25,
+        lastTradedAt: NOW - 600,
+        totalStakers: 200,
+      }),
+      NOW
+    );
+    const dead = scoreToken(metrics(), NOW);
+
+    expect(active.score).toBeGreaterThan(dead.score);
+    expect(dead.score).toBe(0);
+  });
+
+  it("boosts fresh launches", () => {
+    const fresh = scoreToken(metrics({ createdAt: NOW - 3600 }), NOW);
+    const old = scoreToken(metrics({ createdAt: NOW - 30 * 86400 }), NOW);
+
+    expect(fresh.score).toBeGreaterThan(old.score);
+    expect(fresh.reasons).toContainEqual(expect.stringContaining("launched"));
+  });
+
+  it("keeps scores within 0-100 even with extreme inputs", () => {
+    const extreme = scoreToken(
+      metrics({
+        volume24h: 1e12,
+        change24h: 100_000,
+        change1h: 100_000,
+        createdAt: NOW,
+        lastTradedAt: NOW,
+        totalStakers: 1_000_000,
+      }),
+      NOW
+    );
+    expect(extreme.score).toBeLessThanOrEqual(100);
+    expect(extreme.score).toBeGreaterThan(90);
+
+    const crash = scoreToken(
+      metrics({ change24h: -99, change1h: -99 }),
+      NOW
+    );
+    expect(crash.score).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not pad reasons with noise for quiet tokens", () => {
+    const quiet = scoreToken(
+      metrics({ volume24h: 12, change24h: 1.2, totalStakers: 3 }),
+      NOW
+    );
+    expect(quiet.reasons).toEqual([]);
+  });
+
+  it("includes legible reasons above the floors", () => {
+    const loud = scoreToken(
+      metrics({
+        volume24h: 12_400,
+        change24h: 18,
+        totalStakers: 234,
+        createdAt: NOW - 6 * 3600,
+      }),
+      NOW
+    );
+    expect(loud.reasons).toEqual([
+      "$12.4k 24h volume",
+      "+18% 24h",
+      "launched 6h ago",
+      "234 stakers",
+    ]);
+  });
+
+  it("handles missing/NaN market data safely", () => {
+    const broken = scoreToken(
+      metrics({ volume24h: NaN, change24h: NaN, marketCap: NaN }),
+      NOW
+    );
+    expect(Number.isFinite(broken.score)).toBe(true);
+  });
+});
+
+describe("rankTokens", () => {
+  it("ranks by score, assigns 1-based ranks, and respects the limit", () => {
+    const tokens = [
+      metrics({ address: "0x01", symbol: "QUIET" }),
+      metrics({
+        address: "0x02",
+        symbol: "HOT",
+        volume24h: 80_000,
+        change24h: 40,
+        lastTradedAt: NOW - 60,
+      }),
+      metrics({
+        address: "0x03",
+        symbol: "WARM",
+        volume24h: 5_000,
+        lastTradedAt: NOW - 3600,
+      }),
+    ];
+
+    const ranked = rankTokens(tokens, NOW, 2);
+    expect(ranked).toHaveLength(2);
+    expect(ranked[0].symbol).toBe("HOT");
+    expect(ranked[0].rank).toBe(1);
+    expect(ranked[1].symbol).toBe("WARM");
+    expect(ranked[1].rank).toBe(2);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@airstack/node": "^0.0.7",
+        "@anthropic-ai/sdk": "^0.104.1",
         "@divvi/referral-sdk": "^2.1.0",
         "@farcaster/auth-kit": "^0.8.1",
         "@farcaster/frame-node": "^0.1.11",
@@ -32,6 +33,7 @@
         "eruda": "^3.4.3",
         "i": "^0.3.7",
         "lucide-react": "^0.546.0",
+        "mcp-handler": "^1.1.0",
         "next": "^15.5.18",
         "next-auth": "^4.24.11",
         "pino-pretty": "^13.1.1",
@@ -114,6 +116,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.104.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.104.1.tgz",
+      "integrity": "sha512-gGACa/+IaiXzRRmF96aOhamoBgapKRBiFWbmmTFP8aMkpaEcuStF+Q61bjo4vPxBM7gqWJNZqsngslRdnLHv0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1555,6 +1578,19 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3549,6 +3585,81 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@mswjs/data": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.16.2.tgz",
@@ -4471,6 +4582,71 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@reown/appkit": {
@@ -8853,6 +9029,12 @@
         "superstruct": "^2.0.2"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -11662,6 +11844,47 @@
         }
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -11728,6 +11951,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -12251,6 +12516,31 @@
       "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/borsh": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
@@ -12400,6 +12690,16 @@
       },
       "engines": {
         "node": ">=6.14.2"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind": {
@@ -12687,6 +12987,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12829,6 +13138,30 @@
         "node": "> 0.10"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -12856,6 +13189,16 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
@@ -12872,6 +13215,24 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -13302,6 +13663,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -13477,6 +13848,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.282",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.282.tgz",
@@ -13509,6 +13887,16 @@
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -13810,6 +14198,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -14291,6 +14686,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eth-block-tracker": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-7.1.0.tgz",
@@ -14545,6 +14950,29 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -14595,6 +15023,106 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/extension-port-stream": {
@@ -14689,11 +15217,34 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -14796,6 +15347,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -14917,6 +15490,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -15000,6 +15593,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -15428,6 +16030,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -15479,6 +16102,23 @@
       "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/idb-keyval": {
@@ -15614,6 +16254,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -15941,6 +16591,13 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -17539,12 +18196,32 @@
       "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==",
       "license": "ISC"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -18125,6 +18802,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mcp-handler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mcp-handler/-/mcp-handler-1.1.0.tgz",
+      "integrity": "sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
+        "redis": "^4.6.0"
+      },
+      "bin": {
+        "create-mcp-route": "dist/cli/index.js",
+        "mcp-adapter": "dist/cli/index.js",
+        "mcp-handler": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "1.26.0",
+        "next": ">=13.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": false
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mcp-handler/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/mcp-handler/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/md5": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
@@ -18143,6 +18869,29 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -18443,6 +19192,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -18738,7 +19497,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18892,6 +19650,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -19179,6 +19950,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -19382,6 +20163,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -19683,6 +20474,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -19962,6 +20767,32 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -20114,6 +20945,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -20169,6 +21017,16 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20259,6 +21117,23 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/rpc-websockets": {
@@ -20429,7 +21304,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -20480,6 +21354,80 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -20535,6 +21483,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/sha.js": {
       "version": "2.4.12",
@@ -20893,11 +21848,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -21502,6 +22466,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/token-types": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
@@ -21554,6 +22528,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -21709,6 +22689,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -21935,6 +22975,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unrs-resolver": {
@@ -22164,6 +23214,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/viem": {
@@ -22740,6 +23800,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@airstack/node": "^0.0.7",
+    "@anthropic-ai/sdk": "^0.104.1",
     "@divvi/referral-sdk": "^2.1.0",
     "@farcaster/auth-kit": "^0.8.1",
     "@farcaster/frame-node": "^0.1.11",
@@ -44,6 +45,7 @@
     "eruda": "^3.4.3",
     "i": "^0.3.7",
     "lucide-react": "^0.546.0",
+    "mcp-handler": "^1.1.0",
     "next": "^15.5.18",
     "next-auth": "^4.24.11",
     "pino-pretty": "^13.1.1",

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,0 +1,155 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
+
+export const metadata: Metadata = {
+  title: "Bring Your Agent - Streme",
+  description:
+    "Streme is agent-native: connect any AI agent via MCP or REST to discover tokens, buy, stake, stream money, and flex yield — with the agent's own wallet.",
+  openGraph: {
+    title: "Bring Your Agent to Streme",
+    description:
+      "Connect any AI agent via MCP to trade, stake, and stream tokens on Base.",
+    type: "website",
+    siteName: "Streme",
+    url: `${baseUrl}/agents`,
+  },
+};
+
+const EXAMPLES = [
+  {
+    prompt: "What's trending on Streme right now?",
+    detail:
+      "Your agent calls get_streme_pulse and reads ranked tokens with human-readable reasons — volume, momentum, staker growth.",
+  },
+  {
+    prompt: "Buy 0.01 ETH of $STREME and stake it",
+    detail:
+      "One unsigned zap transaction: buy + auto-stake in a single signature. Rewards start streaming to the wallet that second.",
+  },
+  {
+    prompt: "Stream 100 $STREME per day to @alice's wallet",
+    detail:
+      "Your agent opens a Superfluid stream — continuous, per-second payments that run until stopped.",
+  },
+  {
+    prompt: "How much yield is my wallet earning?",
+    detail:
+      "get_wallet_yield returns every live reward stream in tokens/day and USD/day, plus a shareable flex card.",
+  },
+];
+
+const MCP_CONFIG = `{
+  "mcpServers": {
+    "streme": {
+      "url": "${baseUrl}/api/mcp"
+    }
+  }
+}`;
+
+const CURL_EXAMPLE = `# Discover
+curl ${baseUrl}/api/agent/tokens?q=streme
+
+# Build a buy + auto-stake transaction (unsigned — you sign it)
+curl -X POST ${baseUrl}/api/agent/tx/buy \\
+  -H "Content-Type: application/json" \\
+  -d '{"tokenAddress":"0x3b3cd21242ba44e9865b066e5ef5d1cc1030cc58","ethAmount":"0.01","stake":true}'`;
+
+export default function AgentsPage() {
+  return (
+    <div className="container mx-auto px-4 pt-24 pb-16 max-w-4xl">
+      <div className="mb-10">
+        <h1 className="text-4xl font-bold mb-3">Bring Your Agent</h1>
+        <p className="text-lg opacity-80 max-w-2xl">
+          Streme is agent-native. Anything you can do here, your AI agent can
+          do for you — discover tokens, buy, stake, stream money by the
+          second, and flex your yield. Your agent signs with{" "}
+          <span className="font-semibold">its own wallet</span>; Streme never
+          holds keys.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-12">
+        {EXAMPLES.map((example) => (
+          <div key={example.prompt} className="card bg-base-100 shadow-sm">
+            <div className="card-body p-5">
+              <p className="font-mono text-sm text-primary">
+                &ldquo;{example.prompt}&rdquo;
+              </p>
+              <p className="text-sm opacity-70">{example.detail}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-10">
+        <section>
+          <h2 className="text-2xl font-semibold mb-3">
+            1. Connect via MCP (recommended)
+          </h2>
+          <p className="opacity-80 mb-4">
+            Add the Streme MCP server to Claude, Cursor, or any MCP-capable
+            agent and it gets ten tools: market data, the live pulse, wallet
+            yield, and unsigned transaction builders for buy / stake / unstake
+            / stream.
+          </p>
+          <div className="mockup-code text-sm">
+            <pre>
+              <code>{MCP_CONFIG}</code>
+            </pre>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-3">2. Or plain REST</h2>
+          <p className="opacity-80 mb-4">
+            Every capability is also a documented REST endpoint. Start at{" "}
+            <Link href="/api/agent" className="link link-primary font-mono">
+              /api/agent
+            </Link>{" "}
+            (self-describing) or{" "}
+            <Link href="/llms.txt" className="link link-primary font-mono">
+              /llms.txt
+            </Link>{" "}
+            (docs your agent can read).
+          </p>
+          <div className="mockup-code text-sm">
+            <pre>
+              <code>{CURL_EXAMPLE}</code>
+            </pre>
+          </div>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-3">How signing works</h2>
+          <p className="opacity-80">
+            Transaction tools return{" "}
+            <span className="font-mono text-sm">
+              {"{ description, tx: { to, data, value?, chainId: 8453 }, notes }"}
+            </span>
+            . Your agent reviews the description, signs with its own wallet,
+            and broadcasts on Base. Unsigned calldata means there is nothing
+            to trust but the math — the same transactions our UI buttons
+            build.
+          </p>
+        </section>
+
+        <section className="card bg-base-200">
+          <div className="card-body">
+            <h2 className="card-title">Why this exists</h2>
+            <p className="opacity-80">
+              Streme tokens stream staking rewards every second — a primitive
+              built for software, not just humans. As agents get better, they
+              need venues where value can flow continuously and
+              programmatically.{" "}
+              <Link href="/pulse" className="link link-primary">
+                Watch the streams live →
+              </Link>
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/[transport]/route.ts
+++ b/src/app/api/[transport]/route.ts
@@ -1,0 +1,216 @@
+// Streme MCP server — makes the whole platform usable by any MCP-capable
+// agent (Claude, Cursor, agent frameworks) at https://streme.fun/api/mcp.
+//
+// Read tools return compact JSON; transaction tools return UNSIGNED
+// transactions for the agent's own wallet to sign on Base. Streme never
+// holds keys, so this surface needs no auth — it's market data plus
+// calldata the caller could construct themselves.
+
+import { createMcpHandler } from "mcp-handler";
+import { z } from "zod";
+import {
+  AgentInputError,
+  buildBuyTxForToken,
+  buildConnectPoolTxForToken,
+  buildStakeTxForToken,
+  buildStreamTx,
+  buildUnstakeTxForToken,
+  capabilities,
+  getPulse,
+  getToken,
+  getYield,
+  listTokens,
+} from "@/src/lib/agent/actions";
+
+export const maxDuration = 60;
+
+const ADDRESS = z
+  .string()
+  .regex(/^0x[a-fA-F0-9]{40}$/, "0x-prefixed EVM address");
+const AMOUNT = z
+  .string()
+  .regex(/^\d+(\.\d+)?$/, 'decimal token amount string, e.g. "1000" or "0.5"');
+
+function json(data: unknown) {
+  return {
+    content: [
+      { type: "text" as const, text: JSON.stringify(data, null, 2) },
+    ],
+  };
+}
+
+function errorResult(error: unknown) {
+  const message =
+    error instanceof AgentInputError
+      ? error.message
+      : error instanceof Error
+      ? `Streme API error: ${error.message}`
+      : "Unknown error";
+  return {
+    content: [{ type: "text" as const, text: message }],
+    isError: true,
+  };
+}
+
+const handler = createMcpHandler(
+  (server) => {
+    server.tool(
+      "get_streme_capabilities",
+      "Overview of Streme (token launchpad on Base where every token streams staking rewards by the second) and everything this server can do. Call this first.",
+      {},
+      async () => json(capabilities())
+    );
+
+    server.tool(
+      "list_streme_tokens",
+      "List or search trending Streme tokens with price, market cap, 24h volume, and staking info.",
+      {
+        query: z
+          .string()
+          .optional()
+          .describe("Filter by name, symbol, or exact address"),
+        limit: z.number().int().min(1).max(50).optional(),
+      },
+      async ({ query, limit }) => {
+        try {
+          return json({ tokens: await listTokens({ query, limit }) });
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "get_streme_token",
+      "Get one Streme token by contract address, including staking contract and reward pool addresses.",
+      { address: ADDRESS },
+      async ({ address }) => {
+        try {
+          return json(await getToken(address));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "get_streme_pulse",
+      "Live market pulse: top tokens ranked by the StremeScore (volume, momentum, freshness, stakers) with human-readable reasons, plus platform totals.",
+      {},
+      async () => {
+        try {
+          return json(await getPulse());
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "get_wallet_yield",
+      "A wallet's live staking reward streams: tokens/day per stream, USD/day where known, and a shareable flex-card URL.",
+      { address: ADDRESS },
+      async ({ address }) => {
+        try {
+          return json(await getYield(address));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "build_buy_transaction",
+      "Build an UNSIGNED transaction that buys a Streme token with ETH (optionally auto-staking the output so rewards stream immediately). Sign and send it with your own wallet on Base (chainId 8453).",
+      {
+        tokenAddress: ADDRESS,
+        ethAmount: AMOUNT.describe('ETH to spend, e.g. "0.01"'),
+        stake: z
+          .boolean()
+          .optional()
+          .describe("Auto-stake the purchased tokens in the same transaction"),
+        slippageBps: z.number().int().min(1).max(5000).optional(),
+      },
+      async (args) => {
+        try {
+          return json(await buildBuyTxForToken(args));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "build_stake_transaction",
+      "Build an UNSIGNED transaction that stakes a Streme token (single ERC777 send to the StakingHelper — no approval step). Staked tokens earn a per-second reward stream.",
+      { tokenAddress: ADDRESS, amount: AMOUNT },
+      async (args) => {
+        try {
+          return json(await buildStakeTxForToken(args));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "build_unstake_transaction",
+      "Build an UNSIGNED transaction that unstakes a Streme token back to a wallet (reverts during the ~24h deposit lock).",
+      {
+        tokenAddress: ADDRESS,
+        to: ADDRESS.describe("Wallet to receive the unstaked tokens"),
+        amount: AMOUNT,
+      },
+      async (args) => {
+        try {
+          return json(await buildUnstakeTxForToken(args));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "build_connect_pool_transaction",
+      "Build an UNSIGNED transaction that connects a wallet to a token's reward pool (one-time per token; makes streamed rewards appear in the wallet balance).",
+      { tokenAddress: ADDRESS },
+      async (args) => {
+        try {
+          return json(await buildConnectPoolTxForToken(args));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+
+    server.tool(
+      "build_stream_transaction",
+      "Build an UNSIGNED transaction that opens/updates a continuous per-second money stream of any Streme token to a receiver (Superfluid CFA). tokensPerDay='0' stops the stream.",
+      {
+        tokenAddress: ADDRESS,
+        receiver: ADDRESS,
+        tokensPerDay: z
+          .string()
+          .regex(/^\d+(\.\d+)?$/)
+          .describe('Tokens per day, e.g. "100". "0" stops the stream.'),
+      },
+      async (args) => {
+        try {
+          return json(buildStreamTx(args));
+        } catch (error) {
+          return errorResult(error);
+        }
+      }
+    );
+  },
+  {
+    serverInfo: { name: "streme", version: "1.0.0" },
+  },
+  {
+    basePath: "/api",
+    maxDuration: 60,
+    verboseLogs: false,
+  }
+);
+
+export { handler as GET, handler as POST, handler as DELETE };

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,0 +1,14 @@
+// Agent gateway discovery document — what Streme can do for your agent.
+
+import { capabilities } from "@/src/lib/agent/actions";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json(capabilities(), {
+    headers: {
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/app/api/agent/token/[address]/route.ts
+++ b/src/app/api/agent/token/[address]/route.ts
@@ -1,0 +1,26 @@
+import { AgentInputError, getToken } from "@/src/lib/agent/actions";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ address: string }> }
+) {
+  const { address } = await context.params;
+  try {
+    const token = await getToken(address);
+    return Response.json(token, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    if (error instanceof AgentInputError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    console.error("[Agent API] token error:", error);
+    return Response.json({ error: "Failed to load token" }, { status: 500 });
+  }
+}

--- a/src/app/api/agent/tokens/route.ts
+++ b/src/app/api/agent/tokens/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { listTokens } from "@/src/lib/agent/actions";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET(request: NextRequest) {
+  try {
+    const query = request.nextUrl.searchParams.get("q") ?? undefined;
+    const limitParam = request.nextUrl.searchParams.get("limit");
+    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+
+    const tokens = await listTokens({ query, limit });
+    return Response.json(
+      { tokens },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[Agent API] tokens error:", error);
+    return Response.json({ error: "Failed to list tokens" }, { status: 500 });
+  }
+}

--- a/src/app/api/agent/tx/[action]/route.ts
+++ b/src/app/api/agent/tx/[action]/route.ts
@@ -1,0 +1,93 @@
+// Unsigned transaction builders for agents: buy, stake, unstake,
+// connect-pool, stream. POST JSON in, { description, tx, notes } out.
+// The caller signs with their own wallet — Streme never holds keys.
+
+import { NextRequest } from "next/server";
+import {
+  AgentInputError,
+  buildBuyTxForToken,
+  buildConnectPoolTxForToken,
+  buildStakeTxForToken,
+  buildStreamTx,
+  buildUnstakeTxForToken,
+} from "@/src/lib/agent/actions";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ action: string }> }
+) {
+  const { action } = await context.params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Body must be JSON" }, { status: 400 });
+  }
+
+  const str = (key: string): string =>
+    typeof body[key] === "string" ? (body[key] as string) : "";
+
+  try {
+    let result;
+    switch (action) {
+      case "buy":
+        result = await buildBuyTxForToken({
+          tokenAddress: str("tokenAddress"),
+          ethAmount: str("ethAmount"),
+          stake: body.stake === true,
+          slippageBps:
+            typeof body.slippageBps === "number" ? body.slippageBps : undefined,
+        });
+        break;
+      case "stake":
+        result = await buildStakeTxForToken({
+          tokenAddress: str("tokenAddress"),
+          amount: str("amount"),
+        });
+        break;
+      case "unstake":
+        result = await buildUnstakeTxForToken({
+          tokenAddress: str("tokenAddress"),
+          to: str("to"),
+          amount: str("amount"),
+        });
+        break;
+      case "connect-pool":
+        result = await buildConnectPoolTxForToken({
+          tokenAddress: str("tokenAddress"),
+        });
+        break;
+      case "stream":
+        result = buildStreamTx({
+          tokenAddress: str("tokenAddress"),
+          receiver: str("receiver"),
+          tokensPerDay: str("tokensPerDay"),
+        });
+        break;
+      default:
+        return Response.json(
+          {
+            error: `Unknown action "${action}". Valid: buy, stake, unstake, connect-pool, stream`,
+          },
+          { status: 404 }
+        );
+    }
+
+    return Response.json(result, {
+      headers: { "Access-Control-Allow-Origin": "*" },
+    });
+  } catch (error) {
+    if (error instanceof AgentInputError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    console.error(`[Agent API] tx/${action} error:`, error);
+    return Response.json(
+      { error: "Failed to build transaction" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/agent/yield/[address]/route.ts
+++ b/src/app/api/agent/yield/[address]/route.ts
@@ -1,0 +1,26 @@
+import { AgentInputError, getYield } from "@/src/lib/agent/actions";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ address: string }> }
+) {
+  const { address } = await context.params;
+  try {
+    const data = await getYield(address);
+    return Response.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  } catch (error) {
+    if (error instanceof AgentInputError) {
+      return Response.json({ error: error.message }, { status: 400 });
+    }
+    console.error("[Agent API] yield error:", error);
+    return Response.json({ error: "Failed to load yield" }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/pulse/route.ts
+++ b/src/app/api/cron/pulse/route.ts
@@ -1,0 +1,48 @@
+// Vercel cron entrypoint for the Pulse engine (see vercel.json crons).
+//
+// Auth model: when CRON_SECRET is set, Vercel sends it as a Bearer token and
+// we require it. When it isn't set (local dev, preview), the run is forced
+// into dry-run mode so no casts can ever be published from an open endpoint.
+
+import { NextRequest } from "next/server";
+import { runPulse } from "@/src/lib/pulse/engine";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  let forceDryRun = request.nextUrl.searchParams.get("dry") === "1";
+
+  if (secret) {
+    const auth = request.headers.get("authorization");
+    if (auth !== `Bearer ${secret}`) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  } else {
+    forceDryRun = true;
+  }
+
+  // Time-travel preview (dry-run only): ?dry=1&at=2026-06-11T16:30:00Z lets
+  // an operator see exactly what the bot would broadcast at that moment.
+  let now: Date | undefined;
+  const at = request.nextUrl.searchParams.get("at");
+  if (at && forceDryRun) {
+    const parsed = new Date(at);
+    if (!Number.isNaN(parsed.getTime())) now = parsed;
+  }
+
+  try {
+    const report = await runPulse({ forceDryRun, now });
+    return Response.json(report);
+  } catch (error) {
+    console.error("[Pulse Cron] Run failed:", error);
+    return Response.json(
+      {
+        error: "Pulse run failed",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/pulse/image/route.tsx
+++ b/src/app/api/pulse/image/route.tsx
@@ -1,0 +1,219 @@
+// Dynamic OG card for /pulse — used by the daily pulse cast embed and any
+// share of the page. Typographic by design: no remote token images means no
+// broken renders, and live numbers are the visual.
+
+import { ImageResponse } from "next/og";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+interface PulseImageToken {
+  symbol: string;
+  marketCap: number;
+  volume24h: number;
+  change24h: number;
+  totalStakers?: number;
+}
+
+function fmtUsd(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "$0";
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}k`;
+  return `$${Math.round(value)}`;
+}
+
+function fmtPct(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  const rounded = Math.abs(value) >= 10 ? Math.round(value) : value.toFixed(1);
+  return `${value >= 0 ? "+" : ""}${rounded}%`;
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const host = request.headers.get("host");
+    const protocol = host?.includes("localhost") ? "http" : "https";
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `${protocol}://${host}`;
+
+    let tokens: PulseImageToken[] = [];
+    let totalVolume = 0;
+    let activeTokens = 0;
+    try {
+      const response = await fetch(`${baseUrl}/api/pulse`, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        tokens = (data?.snapshot?.tokens ?? []).slice(0, 3);
+        totalVolume = data?.snapshot?.totals?.volume24h ?? 0;
+        activeTokens = data?.snapshot?.totals?.activeTokens24h ?? 0;
+      }
+    } catch {
+      // Render the branded card without data rather than failing.
+    }
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            padding: "64px 72px",
+            fontFamily: "system-ui, -apple-system, sans-serif",
+            background:
+              "linear-gradient(135deg, #0b1020 0%, #131a35 55%, #1b1040 100%)",
+            color: "#ffffff",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 64,
+                  fontWeight: 800,
+                  letterSpacing: "-2px",
+                }}
+              >
+                STREME PULSE
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 28,
+                  color: "#8ea0ff",
+                  marginTop: 8,
+                }}
+              >
+                tokens streaming staking rewards, every second
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                width: 28,
+                height: 28,
+                borderRadius: 9999,
+                backgroundColor: "#46e3b7",
+                boxShadow: "0 0 40px 12px rgba(70,227,183,0.45)",
+              }}
+            />
+          </div>
+
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "20px" }}
+          >
+            {tokens.map((token, i) => (
+              <div
+                key={token.symbol + i}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "20px 32px",
+                  borderRadius: 20,
+                  backgroundColor: "rgba(255,255,255,0.06)",
+                  border: "1px solid rgba(255,255,255,0.10)",
+                }}
+              >
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: "24px" }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      fontSize: 36,
+                      fontWeight: 700,
+                      color: "#8ea0ff",
+                      width: 48,
+                    }}
+                  >
+                    {i + 1}
+                  </div>
+                  <div style={{ display: "flex", fontSize: 44, fontWeight: 800 }}>
+                    ${token.symbol}
+                  </div>
+                </div>
+                <div
+                  style={{ display: "flex", alignItems: "center", gap: "36px" }}
+                >
+                  <div style={{ display: "flex", fontSize: 32, color: "#c3cbf5" }}>
+                    {fmtUsd(token.volume24h)} vol
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      fontSize: 32,
+                      fontWeight: 700,
+                      color: token.change24h >= 0 ? "#46e3b7" : "#ff7e9d",
+                    }}
+                  >
+                    {fmtPct(token.change24h)}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {tokens.length === 0 && (
+              <div
+                style={{
+                  display: "flex",
+                  fontSize: 40,
+                  color: "#c3cbf5",
+                  padding: "24px 0",
+                }}
+              >
+                Live rankings of every streaming token on Base
+              </div>
+            )}
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              fontSize: 28,
+              color: "#8ea0ff",
+            }}
+          >
+            <div style={{ display: "flex" }}>
+              {activeTokens > 0
+                ? `${activeTokens} tokens active · ${fmtUsd(
+                    totalVolume
+                  )} 24h volume`
+                : "Launch · Stake · Stream"}
+            </div>
+            <div style={{ display: "flex", fontWeight: 700, color: "#ffffff" }}>
+              streme.fun/pulse
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 800,
+        headers: {
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+          "Content-Type": "image/png",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[Pulse Image] Error:", error);
+    return new NextResponse("Pulse image generation error", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}

--- a/src/app/api/pulse/route.ts
+++ b/src/app/api/pulse/route.ts
@@ -1,0 +1,54 @@
+// Public pulse data for the /pulse page (and anyone else — the snapshot is
+// intentionally open data: ranked tokens, milestones, and the bot's
+// activity log).
+//
+// Reads the latest stored snapshot; when state is cold (no cron configured
+// yet, or fresh in-memory store) it computes a read-only snapshot on demand
+// so the page always has data.
+
+import { computeSnapshot } from "@/src/lib/pulse/engine";
+import {
+  getLatestSnapshot,
+  getRecentCasts,
+  getRecentMilestones,
+  getRecentNotifications,
+  setLatestSnapshot,
+} from "@/src/lib/pulse/store";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const SNAPSHOT_STALE_SECONDS = 30 * 60;
+
+export async function GET() {
+  try {
+    const now = Math.floor(Date.now() / 1000);
+
+    let snapshot = await getLatestSnapshot();
+    if (!snapshot || now - snapshot.generatedAt > SNAPSHOT_STALE_SECONDS) {
+      snapshot = await computeSnapshot(now);
+      await setLatestSnapshot(snapshot);
+    }
+
+    const [milestones, casts, notifications] = await Promise.all([
+      getRecentMilestones(),
+      getRecentCasts(),
+      getRecentNotifications(),
+    ]);
+
+    return Response.json(
+      { snapshot, milestones, casts, notifications },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[Pulse API] Error:", error);
+    return Response.json(
+      { error: "Failed to load pulse data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/yield/[address]/image/route.tsx
+++ b/src/app/api/yield/[address]/image/route.tsx
@@ -1,0 +1,217 @@
+// Dynamic OG card for /yield/[address] — the "flex my stream" share image.
+// Every staker who shares becomes an advertiser for the streaming primitive.
+
+import { ImageResponse } from "next/og";
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+interface FlowData {
+  symbol: string;
+  tokensPerDay: number;
+  usdPerDay: number | null;
+}
+
+function fmtAmount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  if (value >= 1) return value.toFixed(value >= 100 ? 0 : 1);
+  return value.toPrecision(2);
+}
+
+function fmtUsd(value: number): string {
+  if (value >= 1) return `$${value.toFixed(2)}`;
+  return `$${value.toPrecision(2)}`;
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ address: string }> }
+) {
+  const { address } = await context.params;
+
+  try {
+    const host = request.headers.get("host");
+    const protocol = host?.includes("localhost") ? "http" : "https";
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `${protocol}://${host}`;
+
+    let flows: FlowData[] = [];
+    let username: string | null = null;
+    let pfpUrl: string | null = null;
+
+    try {
+      const [yieldRes, userRes] = await Promise.all([
+        fetch(`${baseUrl}/api/yield/${address}`, { cache: "no-store" }),
+        fetch(`${baseUrl}/api/users/by-address?address=${address}`, {
+          cache: "no-store",
+        }),
+      ]);
+      if (yieldRes.ok) {
+        const data = await yieldRes.json();
+        flows = (data?.flows ?? []).slice(0, 3);
+      }
+      if (userRes.ok) {
+        const userData = await userRes.json();
+        const user = userData?.data?.[0] ?? userData?.user;
+        username = user?.username ?? null;
+        pfpUrl = user?.pfp_url ?? null;
+      }
+    } catch {
+      // Render the branded card without data rather than failing.
+    }
+
+    const hero = flows[0];
+    const others = flows.slice(1);
+    const shortAddress = `${address.slice(0, 6)}…${address.slice(-4)}`;
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            height: "100%",
+            width: "100%",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            padding: "64px 72px",
+            fontFamily: "system-ui, -apple-system, sans-serif",
+            background:
+              "linear-gradient(135deg, #0b1020 0%, #131a35 55%, #0c2b25 100%)",
+            color: "#ffffff",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+              {pfpUrl && (
+                <img
+                  src={pfpUrl}
+                  alt=""
+                  width="72"
+                  height="72"
+                  style={{
+                    borderRadius: 9999,
+                    border: "3px solid rgba(255,255,255,0.25)",
+                    objectFit: "cover",
+                  }}
+                />
+              )}
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <div style={{ display: "flex", fontSize: 36, fontWeight: 800 }}>
+                  {username ? `@${username}` : shortAddress}
+                </div>
+                <div
+                  style={{ display: "flex", fontSize: 24, color: "#8ea0ff" }}
+                >
+                  is earning streaming rewards
+                </div>
+              </div>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                width: 28,
+                height: 28,
+                borderRadius: 9999,
+                backgroundColor: "#46e3b7",
+                boxShadow: "0 0 40px 12px rgba(70,227,183,0.45)",
+              }}
+            />
+          </div>
+
+          {hero ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: "20px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 96,
+                    fontWeight: 800,
+                    color: "#46e3b7",
+                    letterSpacing: "-3px",
+                  }}
+                >
+                  +{fmtAmount(hero.tokensPerDay)} ${hero.symbol}
+                </div>
+              </div>
+              <div
+                style={{ display: "flex", fontSize: 36, color: "#c3cbf5" }}
+              >
+                per day, streamed every second
+                {hero.usdPerDay && hero.usdPerDay >= 0.01
+                  ? ` · ~${fmtUsd(hero.usdPerDay)}/day`
+                  : ""}
+              </div>
+              {others.length > 0 && (
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 28,
+                    color: "#8ea0ff",
+                    marginTop: 12,
+                  }}
+                >
+                  also streaming{" "}
+                  {others
+                    .map((f) => `+${fmtAmount(f.tokensPerDay)} $${f.symbol}`)
+                    .join(" · ")}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div
+              style={{ display: "flex", fontSize: 48, color: "#c3cbf5" }}
+            >
+              Stake any Streme token to start a reward stream
+            </div>
+          )}
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              fontSize: 28,
+              color: "#8ea0ff",
+            }}
+          >
+            <div style={{ display: "flex" }}>
+              stake early, earn the stream
+            </div>
+            <div style={{ display: "flex", fontWeight: 700, color: "#ffffff" }}>
+              streme.fun
+            </div>
+          </div>
+        </div>
+      ),
+      {
+        width: 1200,
+        height: 800,
+        headers: {
+          "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+          "Content-Type": "image/png",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[Yield Image] Error:", error);
+    return new NextResponse("Yield image generation error", {
+      status: 500,
+      headers: { "Content-Type": "text/plain" },
+    });
+  }
+}

--- a/src/app/api/yield/[address]/route.ts
+++ b/src/app/api/yield/[address]/route.ts
@@ -1,0 +1,34 @@
+// Public yield data for a wallet — powers /yield/[address] and its OG card.
+
+import { getAccountYield } from "@/src/lib/yield";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ address: string }> }
+) {
+  const { address } = await context.params;
+
+  if (!ADDRESS_RE.test(address)) {
+    return Response.json({ error: "Invalid address" }, { status: 400 });
+  }
+
+  try {
+    const accountYield = await getAccountYield(address);
+    return Response.json(accountYield, {
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
+  } catch (error) {
+    console.error("[Yield API] Error:", error);
+    return Response.json(
+      { error: "Failed to load yield data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,65 @@
+// /llms.txt — machine-readable platform docs, the convention agents and
+// LLM crawlers check first. Everything here is public information.
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const base =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_URL ||
+    "https://streme.fun";
+
+  const text = `# Streme
+
+> Streme is a token launchpad on Base (chainId 8453) where every token is a native Superfluid Super Token that streams staking rewards by the second. Stake any Streme token and rewards flow into your wallet continuously — no claiming, no epochs. Trading fees feed the flywheel: a share streams back to stakers and buys back $STREME.
+
+Streme is agent-native: anything a user can do in the UI, an agent can do through the gateway below. Streme never holds keys — transaction endpoints return UNSIGNED transactions for the agent's own wallet to sign on Base.
+
+## Agent Gateway
+
+- MCP server (recommended): ${base}/api/mcp — streamable HTTP transport. Add this URL to any MCP-capable agent (Claude, Cursor, agent frameworks). Tools: get_streme_capabilities, list_streme_tokens, get_streme_token, get_streme_pulse, get_wallet_yield, build_buy_transaction, build_stake_transaction, build_unstake_transaction, build_connect_pool_transaction, build_stream_transaction.
+- REST: ${base}/api/agent — self-describing capabilities document with all endpoints.
+
+## Core flows for agents
+
+1. Discover: GET ${base}/api/agent/tokens?q=<search> or the get_streme_pulse tool for ranked trending tokens with reasons.
+2. Buy (+ auto-stake): POST ${base}/api/agent/tx/buy {"tokenAddress","ethAmount","stake":true} → unsigned zap transaction. Sign with your wallet; the output is staked and rewards stream to you immediately.
+3. Stake existing tokens: POST ${base}/api/agent/tx/stake {"tokenAddress","amount"} → a single ERC777 send() to the StakingHelper. No approval transaction needed.
+4. Connect the reward pool (once per token): POST ${base}/api/agent/tx/connect-pool {"tokenAddress"} — makes streamed rewards visible in the wallet balance.
+5. Stream money: POST ${base}/api/agent/tx/stream {"tokenAddress","receiver","tokensPerDay"} — open a continuous per-second stream to any address (Superfluid CFA). "0" stops it.
+6. Show off: GET ${base}/api/agent/yield/<address> returns live reward streams and a shareable flex-card URL (${base}/yield/<address>).
+
+## Transaction contract
+
+All tx endpoints return: { "description", "tx": { "to", "data", "value"?, "chainId": 8453 }, "notes": [] }. Always sign on Base (chainId 8453). Amounts are decimal strings in whole tokens (18 decimals handled server-side).
+
+## Key facts
+
+- Token supply: 100B per token. Default: 20% streams to stakers over 365 days (V2 tokens configurable, plus team vaults with lockup + vesting).
+- Staking: stake → stTOKEN 1:1; rewards proportional to your share of staked supply; ~24h deposit lock, reset on each stake.
+- Trading fees (1% Uniswap V3 tier): 40% to the token's creator, 60% to the protocol flywheel (staker boosts + $STREME buybacks).
+- Launching: via the Streme UI (${base}/launch) or by casting "@streme" on Farcaster with a name + ticker.
+- Live market data: GET ${base}/api/pulse (rankings, milestones, automated bot activity).
+
+## Pages
+
+- ${base}/ — token discovery and trading
+- ${base}/pulse — live rankings, milestones, bot activity
+- ${base}/launch — launch a token
+- ${base}/yield/<address> — a wallet's live streaming yield (shareable)
+- ${base}/agents — human-readable guide to this gateway
+
+## Source docs
+
+- Farcaster mini-app docs: https://miniapps.farcaster.xyz/llms-full.txt
+- Superfluid protocol: https://docs.superfluid.org
+`;
+
+  return new Response(text, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}

--- a/src/app/pulse/PulseContent.tsx
+++ b/src/app/pulse/PulseContent.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import SafeImage from "@/src/components/SafeImage";
+import type {
+  CastRecord,
+  Milestone,
+  PulseSnapshot,
+} from "@/src/lib/pulse/types";
+import {
+  formatCountCompact,
+  formatPercentChange,
+  formatUsdCompact,
+} from "@/src/lib/pulse/format";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+interface PulseData {
+  snapshot: PulseSnapshot;
+  milestones: Milestone[];
+  casts: CastRecord[];
+}
+
+function relativeTime(unixSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(Date.now() / 1000) - unixSeconds);
+  if (seconds < 60) return "just now";
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+function formatPrice(price: number): string {
+  if (!Number.isFinite(price) || price <= 0) return "$0";
+  if (price >= 0.01) return `$${price.toFixed(2)}`;
+  // Expand tiny prices instead of scientific notation: $0.00000017
+  const decimals = Math.min(12, -Math.floor(Math.log10(price)) + 2);
+  return `$${price.toFixed(decimals)}`;
+}
+
+const CAST_STATUS_BADGES: Record<CastRecord["status"], string> = {
+  published: "badge-success",
+  dry_run: "badge-info",
+  failed: "badge-error",
+  skipped: "badge-ghost",
+};
+
+export default function PulseContent() {
+  const [data, setData] = useState<PulseData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPulse = useCallback(async () => {
+    try {
+      const response = await fetch("/api/pulse");
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const pulseData: PulseData = await response.json();
+      setData(pulseData);
+      setError(null);
+    } catch (err) {
+      console.error("Error fetching pulse data:", err);
+      setError("Failed to load pulse data");
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPulse();
+    const interval = setInterval(fetchPulse, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchPulse]);
+
+  if (error && !data) {
+    return (
+      <div className="container mx-auto px-4 py-24 max-w-6xl text-center">
+        <div className="alert alert-error max-w-md mx-auto">
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="container mx-auto px-4 pt-24 pb-12 max-w-6xl">
+        <div className="flex items-center gap-3 mb-8">
+          <h1 className="text-4xl font-bold">Streme Pulse</h1>
+        </div>
+        <div className="flex justify-center py-24">
+          <span className="loading loading-spinner loading-lg text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  const { snapshot, milestones, casts } = data;
+
+  return (
+    <div className="container mx-auto px-4 pt-24 pb-12 max-w-6xl">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3">
+          <h1 className="text-4xl font-bold">Streme Pulse</h1>
+          <span className="relative flex h-3 w-3 mt-1">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-success opacity-75" />
+            <span className="relative inline-flex rounded-full h-3 w-3 bg-success" />
+          </span>
+        </div>
+        <p className="mt-2 opacity-70">
+          What&apos;s streaming right now — live rankings, milestones, and the
+          automated @streme broadcast log. Updated {relativeTime(snapshot.generatedAt)}.
+        </p>
+      </div>
+
+      {/* Totals */}
+      <div className="stats stats-vertical sm:stats-horizontal shadow w-full mb-10 bg-base-100">
+        <div className="stat">
+          <div className="stat-title">24h Volume</div>
+          <div className="stat-value text-primary font-mono">
+            {formatUsdCompact(snapshot.totals.volume24h)}
+          </div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Active Tokens (24h)</div>
+          <div className="stat-value font-mono">
+            {formatCountCompact(snapshot.totals.activeTokens24h)}
+          </div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Launches (7d)</div>
+          <div className="stat-value font-mono">
+            {formatCountCompact(snapshot.totals.launches7d)}
+          </div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">Combined Market Cap</div>
+          <div className="stat-value font-mono">
+            {formatUsdCompact(snapshot.totals.marketCap)}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Rankings */}
+        <div className="lg:col-span-2">
+          <h2 className="text-xl font-semibold mb-4">Top Streaming Tokens</h2>
+          <div className="space-y-3">
+            {snapshot.tokens.map((token) => (
+              <Link
+                key={token.address}
+                href={`/token/${token.address}`}
+                className="block"
+              >
+                <div className="card bg-base-100 shadow-sm hover:shadow-md transition-shadow">
+                  <div className="card-body p-4">
+                    <div className="flex items-center gap-4">
+                      <div className="text-lg font-bold opacity-50 w-8 text-center shrink-0">
+                        {token.rank}
+                      </div>
+                      <div className="avatar shrink-0">
+                        <div className="w-12 h-12 rounded-xl">
+                          <SafeImage
+                            src={token.img_url ?? undefined}
+                            alt={token.name}
+                            width={48}
+                            height={48}
+                            className="rounded-xl object-cover"
+                          />
+                        </div>
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-2">
+                          <span className="font-semibold truncate">
+                            {token.name}
+                          </span>
+                          <span className="text-sm opacity-60">
+                            ${token.symbol}
+                          </span>
+                        </div>
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {token.reasons.map((reason) => (
+                            <span
+                              key={reason}
+                              className="badge badge-ghost badge-sm"
+                            >
+                              {reason}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="font-mono font-semibold">
+                          {formatPrice(token.price)}
+                        </div>
+                        {token.change24h === 0 && token.volume24h === 0 ? (
+                          <div className="font-mono text-sm opacity-40">—</div>
+                        ) : (
+                          <div
+                            className={`font-mono text-sm ${
+                              token.change24h >= 0
+                                ? "text-success"
+                                : "text-error"
+                            }`}
+                          >
+                            {formatPercentChange(token.change24h)}
+                          </div>
+                        )}
+                      </div>
+                      <div className="text-right shrink-0 hidden sm:block w-24">
+                        <div className="text-xs opacity-50">MCap</div>
+                        <div className="font-mono text-sm">
+                          {formatUsdCompact(token.marketCap)}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+            {snapshot.tokens.length === 0 && (
+              <div className="text-center py-12 opacity-60">
+                No ranked tokens right now
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Side column */}
+        <div className="space-y-8">
+          <div>
+            <h2 className="text-xl font-semibold mb-4">Milestones</h2>
+            <div className="card bg-base-100 shadow-sm">
+              <div className="card-body p-4 space-y-3">
+                {milestones.length === 0 && (
+                  <p className="text-sm opacity-60">
+                    No milestones yet. When a token crosses a market cap
+                    level, it shows up here — and the @streme bot celebrates
+                    it onchain.
+                  </p>
+                )}
+                {milestones.slice(0, 10).map((milestone) => (
+                  <Link
+                    key={milestone.id}
+                    href={`/token/${milestone.tokenAddress}`}
+                    className="block hover:bg-base-200 rounded-lg p-2 -m-2 transition-colors"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold truncate">
+                        ${milestone.symbol}
+                      </span>
+                      <span className="badge badge-primary badge-sm shrink-0">
+                        {formatUsdCompact(milestone.threshold)} mcap
+                      </span>
+                    </div>
+                    <div className="text-xs opacity-50 mt-1">
+                      {relativeTime(milestone.detectedAt)}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold mb-4">Bot Activity</h2>
+            <div className="card bg-base-100 shadow-sm">
+              <div className="card-body p-4 space-y-4">
+                {casts.length === 0 && (
+                  <p className="text-sm opacity-60">
+                    The Pulse engine hasn&apos;t broadcast anything yet. Daily
+                    pulse casts and milestone celebrations will appear here.
+                  </p>
+                )}
+                {casts.slice(0, 8).map((cast) => (
+                  <div key={cast.idem + cast.createdAt}>
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-semibold uppercase opacity-60">
+                        {cast.kind.replace("_", " ")}
+                      </span>
+                      <span
+                        className={`badge badge-sm ${
+                          CAST_STATUS_BADGES[cast.status]
+                        }`}
+                      >
+                        {cast.status.replace("_", " ")}
+                      </span>
+                    </div>
+                    <p className="text-sm mt-1 whitespace-pre-line line-clamp-4 opacity-80">
+                      {cast.text}
+                    </p>
+                    <div className="text-xs opacity-50 mt-1">
+                      {relativeTime(cast.createdAt)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs opacity-50 mt-12 max-w-2xl">
+        This page is generated by the Streme Pulse engine: a transparent,
+        automated ranking of every Streme token by volume, momentum,
+        freshness, and staking activity. The same engine powers the @streme
+        bot&apos;s automated casts — every broadcast it makes (or skips) is
+        logged above.
+      </p>
+    </div>
+  );
+}

--- a/src/app/pulse/page.tsx
+++ b/src/app/pulse/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import PulseContent from "./PulseContent";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
+const pageUrl = `${baseUrl}/pulse`;
+const imageUrl = `${baseUrl}/api/pulse/image`;
+
+const frameEmbed = {
+  version: "next",
+  imageUrl,
+  button: {
+    title: "Open Streme Pulse",
+    action: {
+      type: "launch_frame",
+      name: "Streme",
+      url: pageUrl,
+      splashImageUrl: `${baseUrl}/icon.png`,
+      splashBackgroundColor: "#ffffff",
+    },
+  },
+};
+
+export const metadata: Metadata = {
+  title: "Streme Pulse - Live Streaming Token Rankings",
+  description:
+    "What's streaming right now on Streme: live token rankings, milestones, and the automated @streme bot activity log.",
+  openGraph: {
+    title: "Streme Pulse",
+    description:
+      "Live rankings of tokens streaming staking rewards every second on Base.",
+    images: [{ url: imageUrl, width: 1200, height: 800, alt: "Streme Pulse" }],
+    type: "website",
+    siteName: "Streme",
+    url: pageUrl,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Streme Pulse",
+    description:
+      "Live rankings of tokens streaming staking rewards every second on Base.",
+    images: [imageUrl],
+    site: "@streme",
+  },
+  other: {
+    "fc:frame": JSON.stringify(frameEmbed),
+  },
+};
+
+export default function PulsePage() {
+  return <PulseContent />;
+}

--- a/src/app/tokens/page.tsx
+++ b/src/app/tokens/page.tsx
@@ -1452,9 +1452,16 @@ export default function TokensPage() {
         <HeroAnimationMini />
       </div>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
-        <div className="mb-8">
+        <div className="mb-8 flex items-center justify-between gap-4">
           <h1 className="text-3xl font-bold mb-2">My Tokens</h1>
-          {/* <p className="text-gray-600">Manage your Streme tokens</p> */}
+          {mounted && effectiveAddress && (
+            <Link
+              href={`/yield/${effectiveAddress.toLowerCase()}`}
+              className="btn btn-outline btn-primary btn-sm"
+            >
+              Share My Stream 🌊
+            </Link>
+          )}
         </div>
 
         {!mounted ? (

--- a/src/app/yield/[address]/YieldContent.tsx
+++ b/src/app/yield/[address]/YieldContent.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import sdk from "@farcaster/miniapp-sdk";
+import SafeImage from "@/src/components/SafeImage";
+import { useAppFrameLogic } from "@/src/hooks/useAppFrameLogic";
+import type { AccountYield, YieldFlow } from "@/src/lib/yield";
+
+interface YieldIdentity {
+  username?: string;
+  pfp_url?: string;
+}
+
+function shortAddress(address: string): string {
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function formatAmount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(2)}M`;
+  if (value >= 1_000)
+    return value.toLocaleString("en-US", { maximumFractionDigits: 0 });
+  if (value >= 1) return value.toFixed(2);
+  return value.toPrecision(3);
+}
+
+/** Live counter for one stream, accumulating from page load. */
+function StreamedSinceLoad({ tokensPerDay }: { tokensPerDay: number }) {
+  const [loadedAt] = useState(() => Date.now());
+  const [, forceTick] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => forceTick((t) => t + 1), 50);
+    return () => clearInterval(interval);
+  }, []);
+
+  const streamed = ((Date.now() - loadedAt) / 1000) * (tokensPerDay / 86400);
+  return (
+    <span className="font-mono text-success">
+      +{streamed.toFixed(6)}
+    </span>
+  );
+}
+
+export default function YieldContent({ address }: { address: string }) {
+  const [data, setData] = useState<AccountYield | null>(null);
+  const [identity, setIdentity] = useState<YieldIdentity | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { isMiniAppView, isSDKLoaded } = useAppFrameLogic();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [yieldRes, userRes] = await Promise.all([
+          fetch(`/api/yield/${address}`),
+          fetch(`/api/users/by-address?address=${address}`),
+        ]);
+        if (!yieldRes.ok) throw new Error(`HTTP ${yieldRes.status}`);
+        setData(await yieldRes.json());
+        if (userRes.ok) {
+          const userData = await userRes.json();
+          const user = userData?.data?.[0] ?? userData?.user;
+          if (user) setIdentity(user);
+        }
+      } catch (err) {
+        console.error("Error loading yield data:", err);
+        setError("Failed to load yield data");
+      }
+    };
+    load();
+  }, [address]);
+
+  const heroFlow: YieldFlow | undefined = data?.flows[0];
+
+  const castText = useMemo(() => {
+    if (!heroFlow) return "Streaming staking rewards every second on Streme 🌊";
+    const more =
+      (data?.flows.length ?? 0) > 1
+        ? ` (+${(data!.flows.length - 1)} more streams)`
+        : "";
+    return `I'm earning +${formatAmount(heroFlow.tokensPerDay)} $${
+      heroFlow.symbol
+    }/day just for staking on Streme${more} 🌊\n\nStreamed to my wallet every second, onchain.`;
+  }, [heroFlow, data]);
+
+  const handleShare = useCallback(async () => {
+    const shareUrl = `${window.location.origin}/yield/${address}`;
+    if (isMiniAppView && isSDKLoaded && sdk) {
+      try {
+        await sdk.actions.composeCast({ text: castText, embeds: [shareUrl] });
+        return;
+      } catch (error) {
+        console.error("Error composing cast:", error);
+      }
+    }
+    window.open(
+      `https://farcaster.xyz/~/compose?text=${encodeURIComponent(
+        castText
+      )}&embeds[]=${encodeURIComponent(shareUrl)}`,
+      "_blank"
+    );
+  }, [address, castText, isMiniAppView, isSDKLoaded]);
+
+  if (error && !data) {
+    return (
+      <div className="container mx-auto px-4 pt-24 pb-12 max-w-3xl text-center">
+        <div className="alert alert-error max-w-md mx-auto">
+          <span>{error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="container mx-auto px-4 pt-24 pb-12 max-w-3xl">
+        <div className="flex justify-center py-24">
+          <span className="loading loading-spinner loading-lg text-primary" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 pt-24 pb-12 max-w-3xl">
+      {/* Identity */}
+      <div className="flex items-center gap-4 mb-8">
+        <div className="avatar">
+          <div className="w-14 h-14 rounded-full">
+            <SafeImage
+              src={identity?.pfp_url}
+              alt="profile"
+              width={56}
+              height={56}
+              className="rounded-full object-cover"
+            />
+          </div>
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">
+            {identity?.username
+              ? `@${identity.username}`
+              : shortAddress(address)}
+          </h1>
+          <p className="opacity-70 text-sm">
+            {data.activeStreams > 0
+              ? `${data.activeStreams} live reward stream${
+                  data.activeStreams === 1 ? "" : "s"
+                }, paid every second`
+              : "No active reward streams yet"}
+          </p>
+        </div>
+      </div>
+
+      {data.flows.length === 0 ? (
+        <div className="card bg-base-100 shadow-sm">
+          <div className="card-body items-center text-center py-16">
+            <p className="text-lg opacity-70 max-w-md">
+              This wallet isn&apos;t earning streaming rewards yet. Stake any
+              Streme token and rewards start flowing into your wallet every
+              second.
+            </p>
+            <Link href="/" className="btn btn-primary mt-4">
+              Explore Tokens
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Hero stream */}
+          {heroFlow && (
+            <div className="card bg-base-100 shadow-md mb-6 overflow-hidden">
+              <div className="card-body">
+                <div className="flex items-center gap-4">
+                  <div className="avatar">
+                    <div className="w-16 h-16 rounded-2xl">
+                      <SafeImage
+                        src={heroFlow.img_url}
+                        alt={heroFlow.name}
+                        width={64}
+                        height={64}
+                        className="rounded-2xl object-cover"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex-1">
+                    <div className="text-4xl font-bold font-mono text-success">
+                      +{formatAmount(heroFlow.tokensPerDay)}
+                    </div>
+                    <div className="opacity-70">
+                      ${heroFlow.symbol} per day
+                      {heroFlow.usdPerDay && heroFlow.usdPerDay >= 0.01
+                        ? ` · ≈ $${heroFlow.usdPerDay.toFixed(2)}/day`
+                        : ""}
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-3 text-sm opacity-70">
+                  Streamed since you opened this page:{" "}
+                  <StreamedSinceLoad tokensPerDay={heroFlow.tokensPerDay} />{" "}
+                  ${heroFlow.symbol}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Other streams */}
+          {data.flows.length > 1 && (
+            <div className="card bg-base-100 shadow-sm mb-6">
+              <div className="card-body p-4 space-y-3">
+                {data.flows.slice(1).map((flow) => (
+                  <Link
+                    key={flow.tokenAddress}
+                    href={`/token/${flow.tokenAddress}`}
+                    className="flex items-center gap-3 hover:bg-base-200 rounded-lg p-2 -m-2 transition-colors"
+                  >
+                    <div className="avatar">
+                      <div className="w-9 h-9 rounded-lg">
+                        <SafeImage
+                          src={flow.img_url}
+                          alt={flow.name}
+                          width={36}
+                          height={36}
+                          className="rounded-lg object-cover"
+                        />
+                      </div>
+                    </div>
+                    <span className="font-semibold flex-1 truncate">
+                      ${flow.symbol}
+                    </span>
+                    <span className="font-mono text-sm text-success">
+                      +{formatAmount(flow.tokensPerDay)}/day
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Share */}
+          <button onClick={handleShare} className="btn btn-primary w-full">
+            Share My Stream 🌊
+          </button>
+        </>
+      )}
+
+      <p className="text-xs opacity-50 mt-10 text-center">
+        Streme tokens stream staking rewards by the second via Superfluid.{" "}
+        <Link href="/pulse" className="link">
+          See what&apos;s streaming now →
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/yield/[address]/page.tsx
+++ b/src/app/yield/[address]/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import YieldContent from "./YieldContent";
+
+interface Props {
+  params: Promise<{ address: string }>;
+}
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { address } = await props.params;
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
+  const pageUrl = `${baseUrl}/yield/${address}`;
+  const imageUrl = `${baseUrl}/api/yield/${address}/image`;
+
+  const frameEmbed = {
+    version: "next",
+    imageUrl,
+    button: {
+      title: "See my stream",
+      action: {
+        type: "launch_frame",
+        name: "Streme",
+        url: pageUrl,
+        splashImageUrl: `${baseUrl}/icon.png`,
+        splashBackgroundColor: "#ffffff",
+      },
+    },
+  };
+
+  const title = "Streaming Yield - Streme";
+  const description =
+    "Staking rewards streamed every second on Base. See this wallet's live streams and start your own.";
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [{ url: imageUrl, width: 1200, height: 800, alt: "Streaming yield" }],
+      type: "website",
+      siteName: "Streme",
+      url: pageUrl,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [imageUrl],
+      site: "@streme",
+    },
+    other: {
+      "fc:frame": JSON.stringify(frameEmbed),
+    },
+  };
+}
+
+export default async function YieldPage(props: Props) {
+  const { address } = await props.params;
+
+  if (!ADDRESS_RE.test(address)) {
+    return (
+      <div className="container mx-auto px-4 pt-24 pb-12 max-w-3xl text-center">
+        <div className="alert alert-error max-w-md mx-auto">
+          <span>Invalid wallet address</span>
+        </div>
+      </div>
+    );
+  }
+
+  return <YieldContent address={address.toLowerCase()} />;
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -171,6 +171,10 @@ export function Navbar() {
           </div>
 
           <div className="hidden md:flex items-center gap-6">
+            <Link href="/pulse" className="btn btn-ghost">
+              Pulse
+            </Link>
+
             {/* link to create page */}
             <Link href="/launch" className="btn btn-primary">
               Launch a Token
@@ -280,6 +284,14 @@ export function Navbar() {
               className="btn btn-primary w-full justify-start"
             >
               Launch a Token
+            </Link>
+
+            <Link
+              href="/pulse"
+              className="btn btn-ghost w-full justify-start"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              Pulse
             </Link>
 
             {isConnected && (

--- a/src/lib/agent/actions.ts
+++ b/src/lib/agent/actions.ts
@@ -1,0 +1,289 @@
+// Agent gateway actions — the shared layer behind both the REST API
+// (/api/agent/*) and the MCP server (/api/mcp). Everything here returns
+// plain JSON designed to be read by language models: compact, labeled,
+// self-explanatory.
+
+import { SPAMMER_BLACKLIST, BLACKLISTED_TOKENS } from "@/src/lib/blacklist";
+import { getAccountYield } from "@/src/lib/yield";
+import { computeSnapshot } from "@/src/lib/pulse/engine";
+import { getLatestSnapshot, setLatestSnapshot } from "@/src/lib/pulse/store";
+import {
+  AgentInputError,
+  assertAddress,
+  buildBuyTx,
+  buildConnectPoolTx,
+  buildStakeTx,
+  buildStreamTx,
+  buildUnstakeTx,
+} from "./txBuilders";
+
+export { AgentInputError };
+
+const TOKEN_URL = "https://api.streme.fun/token";
+const TRENDING_URL = "https://api.streme.fun/api/tokens/trending?type=all";
+
+function appUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_URL ||
+    "https://streme.fun"
+  );
+}
+
+interface UpstreamToken {
+  contract_address?: string;
+  name?: string;
+  symbol?: string;
+  img_url?: string | null;
+  username?: string;
+  type?: string;
+  staking_address?: string;
+  staking_pool?: string;
+  timestamp?: { _seconds?: number };
+  lastTraded?: { _seconds?: number };
+  marketData?: {
+    marketCap?: number;
+    price?: number;
+    volume24h?: number;
+    priceChange24h?: number;
+  };
+}
+
+export interface AgentToken {
+  address: string;
+  name: string;
+  symbol: string;
+  creatorFarcasterUsername?: string;
+  createdAt: number;
+  priceUsd: number;
+  marketCapUsd: number;
+  volume24hUsd: number;
+  priceChange24hPct: number;
+  lastTradedAt: number;
+  staking: {
+    stakingAddress?: string;
+    rewardPoolAddress?: string;
+    lpType: "uniswap" | "aero";
+    howToStake: string;
+  };
+  pageUrl: string;
+}
+
+function toAgentToken(t: UpstreamToken): AgentToken | null {
+  const address = t.contract_address?.toLowerCase();
+  if (!address || !t.name || !t.symbol) return null;
+  return {
+    address,
+    name: t.name,
+    symbol: t.symbol.replace(/^\$/, ""),
+    creatorFarcasterUsername: t.username,
+    createdAt: t.timestamp?._seconds ?? 0,
+    priceUsd: t.marketData?.price ?? 0,
+    marketCapUsd: t.marketData?.marketCap ?? 0,
+    volume24hUsd: t.marketData?.volume24h ?? 0,
+    priceChange24hPct: t.marketData?.priceChange24h ?? 0,
+    lastTradedAt: t.lastTraded?._seconds ?? 0,
+    staking: {
+      stakingAddress: t.staking_address?.toLowerCase(),
+      rewardPoolAddress: t.staking_pool?.toLowerCase(),
+      lpType:
+        t.type === "v2aero" || t.type === "v2aeronew" ? "aero" : "uniswap",
+      howToStake:
+        "Use build_stake_transaction (a single ERC777 send to the StakingHelper — no approval), then build_connect_pool_transaction once so rewards show in the balance.",
+    },
+    pageUrl: `${appUrl()}/token/${address}`,
+  };
+}
+
+function blacklisted(t: UpstreamToken): boolean {
+  if (t.username && SPAMMER_BLACKLIST.includes(t.username.toLowerCase()))
+    return true;
+  if (
+    t.contract_address &&
+    BLACKLISTED_TOKENS.includes(t.contract_address.toLowerCase())
+  )
+    return true;
+  return false;
+}
+
+export async function listTokens(params: {
+  query?: string;
+  limit?: number;
+}): Promise<AgentToken[]> {
+  const limit = Math.min(Math.max(params.limit ?? 10, 1), 50);
+  const response = await fetch(TRENDING_URL, {
+    headers: { Accept: "application/json", "User-Agent": "Streme-Agent/1.0" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`Trending API error: ${response.status}`);
+
+  const tokens: UpstreamToken[] = await response.json();
+  const q = params.query?.trim().toLowerCase();
+
+  return tokens
+    .filter((t) => !blacklisted(t))
+    .filter((t) => {
+      if (!q) return true;
+      return (
+        t.name?.toLowerCase().includes(q) ||
+        t.symbol?.toLowerCase().replace(/^\$/, "").includes(q) ||
+        t.contract_address?.toLowerCase() === q
+      );
+    })
+    .map(toAgentToken)
+    .filter((t): t is AgentToken => t !== null)
+    .slice(0, limit);
+}
+
+export async function getToken(address: string): Promise<AgentToken> {
+  const normalized = assertAddress(address, "address");
+  const response = await fetch(`${TOKEN_URL}/${normalized}`, {
+    headers: { Accept: "application/json", "User-Agent": "Streme-Agent/1.0" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (response.status === 404) {
+    throw new AgentInputError(`No Streme token found at ${normalized}`);
+  }
+  if (!response.ok) throw new Error(`Token API error: ${response.status}`);
+
+  const payload = await response.json();
+  const token = toAgentToken(payload?.data ?? payload);
+  if (!token) throw new AgentInputError(`No Streme token found at ${normalized}`);
+  return token;
+}
+
+export async function getPulse() {
+  const now = Math.floor(Date.now() / 1000);
+  let snapshot = await getLatestSnapshot();
+  if (!snapshot || now - snapshot.generatedAt > 30 * 60) {
+    snapshot = await computeSnapshot(now);
+    await setLatestSnapshot(snapshot);
+  }
+  return {
+    generatedAt: snapshot.generatedAt,
+    totals: snapshot.totals,
+    topTokens: snapshot.tokens.slice(0, 10).map((t) => ({
+      rank: t.rank,
+      address: t.address,
+      symbol: t.symbol,
+      score: t.score,
+      reasons: t.reasons,
+      priceUsd: t.price,
+      marketCapUsd: t.marketCap,
+      volume24hUsd: t.volume24h,
+      stakers: t.totalStakers,
+      pageUrl: `${appUrl()}/token/${t.address}`,
+    })),
+  };
+}
+
+export async function getYield(address: string) {
+  const normalized = assertAddress(address, "address");
+  const accountYield = await getAccountYield(normalized);
+  return {
+    ...accountYield,
+    flexCardUrl: `${appUrl()}/yield/${normalized}`,
+    note: "Share flexCardUrl to show this wallet's live streams (renders a dynamic image).",
+  };
+}
+
+/**
+ * Buy helper that resolves the token's staking address + LP type when the
+ * caller wants auto-stake but only knows the token address.
+ */
+export async function buildBuyTxForToken(params: {
+  tokenAddress: string;
+  ethAmount: string;
+  stake?: boolean;
+  slippageBps?: number;
+}) {
+  const token = await getToken(params.tokenAddress);
+  return buildBuyTx({
+    tokenAddress: token.address,
+    ethAmount: params.ethAmount,
+    stake: params.stake,
+    stakingAddress: token.staking.stakingAddress,
+    lpType: token.staking.lpType,
+    slippageBps: params.slippageBps,
+  });
+}
+
+export async function buildStakeTxForToken(params: {
+  tokenAddress: string;
+  amount: string;
+}) {
+  // Validate it's a real Streme token before handing out calldata.
+  const token = await getToken(params.tokenAddress);
+  return buildStakeTx({ tokenAddress: token.address, amount: params.amount });
+}
+
+export async function buildUnstakeTxForToken(params: {
+  tokenAddress: string;
+  to: string;
+  amount: string;
+}) {
+  const token = await getToken(params.tokenAddress);
+  if (!token.staking.stakingAddress) {
+    throw new AgentInputError(
+      `Token ${token.symbol} has no staking contract on record`
+    );
+  }
+  return buildUnstakeTx({
+    stakingAddress: token.staking.stakingAddress,
+    to: params.to,
+    amount: params.amount,
+  });
+}
+
+export async function buildConnectPoolTxForToken(params: {
+  tokenAddress: string;
+}) {
+  const token = await getToken(params.tokenAddress);
+  if (!token.staking.rewardPoolAddress) {
+    throw new AgentInputError(
+      `Token ${token.symbol} has no reward pool on record`
+    );
+  }
+  return buildConnectPoolTx({ poolAddress: token.staking.rewardPoolAddress });
+}
+
+export { buildStreamTx };
+
+/** Self-describing capabilities document (GET /api/agent). */
+export function capabilities() {
+  const base = appUrl();
+  return {
+    name: "Streme Agent Gateway",
+    description:
+      "Programmatic access to Streme — a token launchpad on Base where every token streams staking rewards by the second (Superfluid). Agents read market data and receive unsigned transactions to sign with their own wallets. Streme never holds keys.",
+    chain: { name: "Base", chainId: 8453 },
+    mcp: {
+      url: `${base}/api/mcp`,
+      transport: "streamable-http",
+      note: "Add this URL to any MCP-capable agent (Claude, Cursor, etc.) to use Streme as a tool server.",
+    },
+    docs: `${base}/llms.txt`,
+    rest: {
+      "GET /api/agent": "this document",
+      "GET /api/agent/tokens?q=&limit=": "search/list trending Streme tokens",
+      "GET /api/agent/token/{address}": "one token with staking info",
+      "GET /api/agent/yield/{address}": "a wallet's live reward streams",
+      "GET /api/pulse": "trending snapshot, milestones, bot activity",
+      "POST /api/agent/tx/buy":
+        "{tokenAddress, ethAmount, stake?, slippageBps?} → unsigned zap tx (ETH→token, optional auto-stake)",
+      "POST /api/agent/tx/stake":
+        "{tokenAddress, amount} → unsigned ERC777 send to StakingHelper (no approval needed)",
+      "POST /api/agent/tx/unstake":
+        "{tokenAddress, to, amount} → unsigned unstake tx",
+      "POST /api/agent/tx/connect-pool":
+        "{tokenAddress} → unsigned GDA connectPool tx (one-time per token; makes rewards visible)",
+      "POST /api/agent/tx/stream":
+        "{tokenAddress, receiver, tokensPerDay} → unsigned Superfluid stream tx (0 stops the stream)",
+    },
+    txContract: {
+      shape: "{ description, tx: { to, data, value?, chainId }, notes[] }",
+      signing:
+        "Sign and broadcast tx with the agent's own wallet on Base (chainId 8453). Always include chainId.",
+    },
+  };
+}

--- a/src/lib/agent/txBuilders.ts
+++ b/src/lib/agent/txBuilders.ts
@@ -1,0 +1,288 @@
+// Unsigned transaction builders for the agent gateway.
+//
+// Custody model: Streme never holds keys. Every builder returns calldata for
+// the agent's OWN wallet to sign and broadcast — the same transactions the
+// UI buttons produce, expressed as data. chainId is always Base (8453).
+
+import { encodeFunctionData, parseAbi, parseEther } from "viem";
+import {
+  encodeSuperTokenSendData,
+  encodeUnstakeData,
+  encodeZapData,
+  encodeConnectPoolData,
+} from "@/src/lib/abiEncoding";
+import { ZAP_CONTRACT_ADDRESS } from "@/src/lib/contracts";
+import { CFA_V1_FORWARDER } from "@/src/lib/superfluid-contracts";
+import { publicClient } from "@/src/lib/viemClient";
+
+type Address = `0x${string}`;
+
+// Same helper the UI StakeButton uses (auto-stakes on ERC777 receipt).
+export const STAKING_HELPER: Address =
+  "0x6C3D0E968d3C986886EEECA6Ba6Fecc949F17F6e";
+
+const WETH: Address = "0x4200000000000000000000000000000000000006";
+const UNI_QUOTER: Address = "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a";
+const AERO_QUOTER: Address = "0x3d4C22254F86f64B7eC90ab8F7aeC1FBFD271c6C";
+
+export const BASE_CHAIN_ID = 8453;
+
+export interface UnsignedTx {
+  to: Address;
+  data: `0x${string}`;
+  /** Hex wei value; omitted when zero */
+  value?: `0x${string}`;
+  chainId: number;
+}
+
+export interface BuiltTransaction {
+  description: string;
+  tx: UnsignedTx;
+  notes: string[];
+}
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export function assertAddress(value: string, label: string): Address {
+  if (!ADDRESS_RE.test(value)) {
+    throw new AgentInputError(`${label} must be a 0x-prefixed address`);
+  }
+  return value.toLowerCase() as Address;
+}
+
+export class AgentInputError extends Error {}
+
+function parseAmount(value: string, label: string): bigint {
+  let amount: bigint;
+  try {
+    amount = parseEther(value);
+  } catch {
+    throw new AgentInputError(
+      `${label} must be a decimal token amount string, e.g. "1000" or "0.5"`
+    );
+  }
+  if (amount <= 0n) {
+    throw new AgentInputError(`${label} must be greater than zero`);
+  }
+  return amount;
+}
+
+const QUOTER_UNI_ABI = parseAbi([
+  "struct QuoteExactInputSingleParams { address tokenIn; address tokenOut; uint256 amountIn; uint24 fee; uint160 sqrtPriceLimitX96; }",
+  "function quoteExactInputSingle(QuoteExactInputSingleParams params) view returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)",
+]);
+
+const QUOTER_AERO_ABI = parseAbi([
+  "struct QuoteExactInputSingleParams { address tokenIn; address tokenOut; uint256 amountIn; int24 tickSpacing; uint160 sqrtPriceLimitX96; }",
+  "function quoteExactInputSingle(QuoteExactInputSingleParams params) view returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)",
+]);
+
+/** Quote ETH→token on the token's pool and apply slippage (0.5% default). */
+export async function quoteBuyAmountOut(
+  tokenAddress: Address,
+  ethAmountWei: bigint,
+  lpType: "uniswap" | "aero"
+): Promise<bigint> {
+  const result =
+    lpType === "aero"
+      ? await publicClient.readContract({
+          address: AERO_QUOTER,
+          abi: QUOTER_AERO_ABI,
+          functionName: "quoteExactInputSingle",
+          args: [
+            {
+              tokenIn: WETH,
+              tokenOut: tokenAddress,
+              amountIn: ethAmountWei,
+              tickSpacing: 500,
+              sqrtPriceLimitX96: 0n,
+            },
+          ],
+        })
+      : await publicClient.readContract({
+          address: UNI_QUOTER,
+          abi: QUOTER_UNI_ABI,
+          functionName: "quoteExactInputSingle",
+          args: [
+            {
+              tokenIn: WETH,
+              tokenOut: tokenAddress,
+              amountIn: ethAmountWei,
+              fee: 10000,
+              sqrtPriceLimitX96: 0n,
+            },
+          ],
+        });
+  return (result as readonly [bigint, bigint, number, bigint])[0];
+}
+
+/**
+ * Buy a token with ETH via the Streme zap (optionally auto-staking in the
+ * same transaction). `quotedAmountOut` is injectable for tests.
+ */
+export async function buildBuyTx(params: {
+  tokenAddress: string;
+  ethAmount: string;
+  stake?: boolean;
+  stakingAddress?: string;
+  lpType?: "uniswap" | "aero";
+  slippageBps?: number;
+  quotedAmountOut?: bigint;
+}): Promise<BuiltTransaction> {
+  const token = assertAddress(params.tokenAddress, "tokenAddress");
+  const ethWei = parseAmount(params.ethAmount, "ethAmount");
+  const slippageBps = params.slippageBps ?? 50;
+  if (slippageBps < 1 || slippageBps > 5000) {
+    throw new AgentInputError("slippageBps must be between 1 and 5000");
+  }
+
+  const stake = params.stake ?? false;
+  const stakingAddress = stake
+    ? assertAddress(
+        params.stakingAddress ?? "",
+        "stakingAddress (required when stake=true)"
+      )
+    : ("0x0000000000000000000000000000000000000000" as Address);
+
+  const amountOut =
+    params.quotedAmountOut ??
+    (await quoteBuyAmountOut(token, ethWei, params.lpType ?? "uniswap"));
+  const amountOutMin = amountOut - (amountOut * BigInt(slippageBps)) / 10_000n;
+
+  const data = encodeZapData("zap", token, ethWei, amountOutMin, stakingAddress);
+
+  return {
+    description: `Buy ${params.ethAmount} ETH worth of the token via Streme zap${
+      stake ? " and auto-stake the output" : ""
+    }`,
+    tx: {
+      to: ZAP_CONTRACT_ADDRESS as Address,
+      data,
+      value: `0x${ethWei.toString(16)}`,
+      chainId: BASE_CHAIN_ID,
+    },
+    notes: [
+      `amountOutMin is set with ${slippageBps} bps slippage from the live quote`,
+      stake
+        ? "Output is staked automatically; rewards stream to the sender every second"
+        : "Pass stake=true with the token's stakingAddress to auto-stake in the same transaction",
+    ],
+  };
+}
+
+/**
+ * Stake tokens by sending them to the StakingHelper (ERC777 `send` — no
+ * approval needed; the helper auto-stakes back to the sender).
+ */
+export function buildStakeTx(params: {
+  tokenAddress: string;
+  amount: string;
+}): BuiltTransaction {
+  const token = assertAddress(params.tokenAddress, "tokenAddress");
+  const amount = parseAmount(params.amount, "amount");
+
+  return {
+    description: `Stake ${params.amount} tokens — a single send() to the StakingHelper, no approval needed`,
+    tx: {
+      to: token,
+      data: encodeSuperTokenSendData(STAKING_HELPER, amount),
+      chainId: BASE_CHAIN_ID,
+    },
+    notes: [
+      "Staked tokens have a short lock (typically 24h, reset on each stake)",
+      "After staking, call build_connect_pool_transaction once per token so streamed rewards appear in the wallet balance",
+    ],
+  };
+}
+
+/** Unstake from a token's staking contract back to the wallet. */
+export function buildUnstakeTx(params: {
+  stakingAddress: string;
+  to: string;
+  amount: string;
+}): BuiltTransaction {
+  const staking = assertAddress(params.stakingAddress, "stakingAddress");
+  const to = assertAddress(params.to, "to");
+  const amount = parseAmount(params.amount, "amount");
+
+  return {
+    description: `Unstake ${params.amount} staked tokens back to ${params.to}`,
+    tx: {
+      to: staking,
+      data: encodeUnstakeData(to, amount),
+      chainId: BASE_CHAIN_ID,
+    },
+    notes: ["Reverts while the deposit lock (typically 24h) is active"],
+  };
+}
+
+const CONNECT_POOL_ABI_NOTE =
+  "Connecting a GDA pool makes already-earned streaming rewards show up in the wallet's token balance";
+
+/** Connect the wallet to a token's GDA reward pool (one-time per token). */
+export function buildConnectPoolTx(params: {
+  poolAddress: string;
+}): BuiltTransaction {
+  const pool = assertAddress(params.poolAddress, "poolAddress");
+
+  return {
+    description: "Connect to the token's reward pool (GDA forwarder)",
+    tx: {
+      to: "0x6DA13Bde224A05a288748d857b9e7DDEffd1dE08", // GDA v1 forwarder (Base)
+      data: encodeConnectPoolData(pool),
+      chainId: BASE_CHAIN_ID,
+    },
+    notes: [CONNECT_POOL_ABI_NOTE],
+  };
+}
+
+const CFA_SET_FLOWRATE_ABI = parseAbi([
+  "function setFlowrate(address token, address receiver, int96 flowrate) returns (bool)",
+]);
+
+/**
+ * Open, update, or close a continuous money stream (Superfluid CFA).
+ * tokensPerDay = "0" closes the stream.
+ */
+export function buildStreamTx(params: {
+  tokenAddress: string;
+  receiver: string;
+  tokensPerDay: string;
+}): BuiltTransaction {
+  const token = assertAddress(params.tokenAddress, "tokenAddress");
+  const receiver = assertAddress(params.receiver, "receiver");
+
+  let perDay: bigint;
+  try {
+    perDay = parseEther(params.tokensPerDay);
+  } catch {
+    throw new AgentInputError(
+      `tokensPerDay must be a decimal token amount string, e.g. "100" (use "0" to stop the stream)`
+    );
+  }
+  if (perDay < 0n) throw new AgentInputError("tokensPerDay must be >= 0");
+
+  const flowrate = perDay / 86400n; // wei per second
+
+  const data = encodeFunctionData({
+    abi: CFA_SET_FLOWRATE_ABI,
+    functionName: "setFlowrate",
+    args: [token, receiver, flowrate],
+  });
+
+  return {
+    description:
+      perDay === 0n
+        ? `Stop the stream to ${params.receiver}`
+        : `Stream ${params.tokensPerDay} tokens/day to ${params.receiver}, paid every second`,
+    tx: {
+      to: CFA_V1_FORWARDER,
+      data,
+      chainId: BASE_CHAIN_ID,
+    },
+    notes: [
+      "setFlowrate creates, updates, or (at 0) deletes the stream in one call",
+      "Streams run until changed — the sender's balance drains continuously",
+    ],
+  };
+}

--- a/src/lib/notifs.ts
+++ b/src/lib/notifs.ts
@@ -18,10 +18,12 @@ export async function sendFrameNotification({
   fid,
   title,
   body,
+  targetUrl,
 }: {
   fid: number;
   title: string;
   body: string;
+  targetUrl?: string;
 }): Promise<SendFrameNotificationResult> {
   const notificationDetails = await getUserNotificationDetails(fid);
   if (!notificationDetails) {
@@ -37,7 +39,7 @@ export async function sendFrameNotification({
       notificationId: crypto.randomUUID(),
       title,
       body,
-      targetUrl: APP_URL,
+      targetUrl: targetUrl ?? APP_URL,
       tokens: [notificationDetails.token],
     } satisfies SendNotificationRequest),
   });

--- a/src/lib/pulse/ai.ts
+++ b/src/lib/pulse/ai.ts
@@ -1,0 +1,90 @@
+// Optional AI copywriting for bot casts.
+//
+// Template text is the source of truth; when enabled, Claude rewrites it in
+// the @streme voice under hard constraints, and a validator guarantees every
+// number and ticker from the template survives verbatim — any violation
+// falls back to the template. The bot can get wittier as models improve,
+// but it can never hallucinate a stat.
+//
+// Off by default: requires PULSE_AI_COPY=true and ANTHROPIC_API_KEY.
+
+import Anthropic from "@anthropic-ai/sdk";
+import { CastDraft } from "./types";
+import { trimToBytes } from "./casts";
+
+const MAX_CAST_BYTES = 1024;
+
+const SYSTEM_PROMPT = `You rewrite short Farcaster casts for @streme, the bot of streme.fun — a token launchpad on Base where every token streams staking rewards by the second.
+
+Voice: sharp, playful, confident. Crypto-native but never cringe. No hype-spam.
+
+Hard rules:
+- Keep EVERY number, dollar amount, percentage, and $TICKER from the draft EXACTLY as written. Do not add, remove, round, or invent any figure.
+- Keep every @mention exactly as written.
+- Maximum 300 characters.
+- No hashtags. No rocket-ship spam (one emoji max). No financial advice, no promises of returns.
+- Keep the factual claims identical — you are restyling, not rewriting the facts.
+
+Reply with ONLY the rewritten cast text, nothing else.`;
+
+export function aiCopyEnabled(): boolean {
+  return Boolean(
+    process.env.PULSE_AI_COPY === "true" && process.env.ANTHROPIC_API_KEY
+  );
+}
+
+/** Numbers, dollar figures, percents, tickers, and mentions that must survive. */
+export function extractProtectedTokens(text: string): string[] {
+  const matches = text.match(
+    /\$[A-Za-z][A-Za-z0-9]*|\$[\d,.]+[kMB]?|[+-]?\d[\d,.]*%|@[a-z0-9_.-]+/g
+  );
+  return matches ?? [];
+}
+
+export function validateRewrite(original: string, rewritten: string): boolean {
+  if (!rewritten || rewritten.trim().length === 0) return false;
+  if (new TextEncoder().encode(rewritten).length > MAX_CAST_BYTES) return false;
+
+  for (const token of extractProtectedTokens(original)) {
+    if (!rewritten.includes(token)) return false;
+  }
+  return true;
+}
+
+/**
+ * Rewrite a cast draft in the bot voice. Returns the draft unchanged when
+ * disabled, on any API error, or when validation fails. Never throws.
+ */
+export async function polishCastDraft(draft: CastDraft): Promise<CastDraft> {
+  if (!aiCopyEnabled()) return draft;
+
+  try {
+    const client = new Anthropic();
+    const response = await client.messages.create({
+      model: process.env.PULSE_AI_MODEL || "claude-opus-4-8",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Rewrite this ${draft.kind.replace("_", " ")} cast:\n\n${draft.text}`,
+        },
+      ],
+    });
+
+    const block = response.content.find((b) => b.type === "text");
+    const rewritten = block && block.type === "text" ? block.text.trim() : "";
+
+    if (!validateRewrite(draft.text, rewritten)) {
+      console.warn(
+        "[Pulse AI] Rewrite failed validation, using template copy"
+      );
+      return draft;
+    }
+
+    return { ...draft, text: trimToBytes(rewritten, MAX_CAST_BYTES) };
+  } catch (error) {
+    console.warn("[Pulse AI] Copy generation failed, using template:", error);
+    return draft;
+  }
+}

--- a/src/lib/pulse/casts.ts
+++ b/src/lib/pulse/casts.ts
@@ -1,0 +1,179 @@
+// Cast generation + publishing for the @streme bot.
+//
+// Copy is template-based (deterministic, reviewable) with hard quality
+// gates: at low activity the bot says nothing rather than hyping $12 of
+// volume. Publishing is dry-run unless explicitly enabled via env, so the
+// whole pipeline is safe to deploy and observe before going live.
+
+import { CastDraft, CastRecord, Milestone, PulseSnapshot } from "./types";
+import {
+  formatCountCompact,
+  formatPercentChange,
+  formatUsdCompact,
+} from "./format";
+
+const FARCASTER_CAST_MAX_BYTES = 1024;
+
+// Daily cast quality gate: need at least this many tokens with real volume.
+const DAILY_MIN_QUALIFYING_TOKENS = 1;
+const DAILY_MIN_TOKEN_VOLUME_USD = 250;
+const DAILY_MAX_TOKENS = 3;
+
+function appUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_URL ||
+    "https://streme.fun"
+  );
+}
+
+export function liveCastingEnabled(): boolean {
+  return Boolean(
+    process.env.PULSE_CASTS_ENABLED === "true" &&
+      process.env.NEYNAR_API_KEY &&
+      process.env.STREME_SIGNER_UUID
+  );
+}
+
+/**
+ * Daily pulse cast: top tokens with stats. Returns null when activity is
+ * below the quality gate — skipping beats casting embarrassing numbers.
+ */
+export function buildDailyPulseCast(
+  snapshot: PulseSnapshot,
+  dateKey: string
+): CastDraft | null {
+  const qualifying = snapshot.tokens.filter(
+    (t) => t.volume24h >= DAILY_MIN_TOKEN_VOLUME_USD
+  );
+  if (qualifying.length < DAILY_MIN_QUALIFYING_TOKENS) return null;
+
+  const top = qualifying.slice(0, DAILY_MAX_TOKENS);
+  const lines = top.map((t, i) => {
+    const parts = [formatUsdCompact(t.volume24h) + " vol"];
+    if (Math.abs(t.change24h) >= 1) {
+      parts.push(formatPercentChange(t.change24h));
+    }
+    if ((t.totalStakers ?? 0) > 0) {
+      parts.push(`${formatCountCompact(t.totalStakers!)} stakers`);
+    }
+    return `${i + 1}. $${t.symbol} — ${parts.join(" · ")}`;
+  });
+
+  const text = trimToBytes(
+    [
+      `📡 Streme Pulse`,
+      ``,
+      `Top streaming tokens today:`,
+      ...lines,
+      ``,
+      `Every Streme token streams staking rewards by the second. Stake early, earn the stream.`,
+    ].join("\n"),
+    FARCASTER_CAST_MAX_BYTES
+  );
+
+  return {
+    kind: "daily_pulse",
+    idem: `daily_pulse:${dateKey}`,
+    text,
+    embedUrl: `${appUrl()}/pulse`,
+  };
+}
+
+export function buildMilestoneCast(milestone: Milestone): CastDraft {
+  // @mentioning the creator turns every milestone into borrowed
+  // distribution — creators reshare their own wins to their own audience.
+  const creator = milestone.creatorUsername?.trim();
+  const byline = creator ? ` by @${creator}` : "";
+
+  const text = trimToBytes(
+    [
+      `🌊 $${milestone.symbol}${byline} just crossed ${formatUsdCompact(
+        milestone.threshold
+      )} market cap on Streme`,
+      ``,
+      `Holders can stake $${milestone.symbol} to earn streaming rewards every second.`,
+    ].join("\n"),
+    FARCASTER_CAST_MAX_BYTES
+  );
+
+  return {
+    kind: "milestone",
+    idem: milestone.id,
+    text,
+    embedUrl: `${appUrl()}/token/${milestone.tokenAddress}`,
+  };
+}
+
+/**
+ * Publish a cast via Neynar as the @streme bot, or record a dry run when
+ * live casting is disabled. Never throws — failures become records.
+ */
+export async function publishCast(
+  draft: CastDraft,
+  opts: { forceDryRun?: boolean; now?: number } = {}
+): Promise<CastRecord> {
+  const createdAt = opts.now ?? Math.floor(Date.now() / 1000);
+
+  if (opts.forceDryRun || !liveCastingEnabled()) {
+    return { ...draft, status: "dry_run", createdAt };
+  }
+
+  try {
+    const response = await fetch("https://api.neynar.com/v2/farcaster/cast", {
+      method: "POST",
+      headers: {
+        "x-api-key": process.env.NEYNAR_API_KEY!,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        signer_uuid: process.env.STREME_SIGNER_UUID,
+        text: draft.text,
+        embeds: [{ url: draft.embedUrl }],
+        idem: draft.idem.slice(0, 16),
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        ...draft,
+        status: "failed",
+        error: `Neynar ${response.status}: ${body.slice(0, 200)}`,
+        createdAt,
+      };
+    }
+
+    const data = await response.json();
+    return {
+      ...draft,
+      status: "published",
+      castHash: data?.cast?.hash,
+      createdAt,
+    };
+  } catch (error) {
+    return {
+      ...draft,
+      status: "failed",
+      error: error instanceof Error ? error.message : "Unknown error",
+      createdAt,
+    };
+  }
+}
+
+/** Trim to a UTF-8 byte budget without splitting a multi-byte character. */
+export function trimToBytes(text: string, maxBytes: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(text).length <= maxBytes) return text;
+
+  // Slice by code points (not UTF-16 units) so surrogate pairs stay intact.
+  let points = Array.from(text);
+  while (
+    points.length > 0 &&
+    encoder.encode(points.join("") + "…").length > maxBytes
+  ) {
+    points = points.slice(0, -1);
+  }
+  return points.join("") + "…";
+}

--- a/src/lib/pulse/engine.ts
+++ b/src/lib/pulse/engine.ts
@@ -1,0 +1,340 @@
+// The Pulse engine — one run does:
+//   1. fetch + rank tokens with the StremeScore (legible trending)
+//   2. enrich the leaders with live staking data from the Superfluid subgraph
+//   3. detect market-cap milestones (once-ever per token per threshold)
+//   4. build + publish bot casts (daily pulse, milestone celebrations)
+//   5. persist everything for the /pulse page and the bot activity log
+//
+// Side effects are layered: computeSnapshot() is read-only (safe for the
+// public API to call as a fallback), runPulse() owns state + casting.
+
+import { SPAMMER_BLACKLIST, BLACKLISTED_TOKENS } from "@/src/lib/blacklist";
+import { fetchBatchPoolData } from "@/src/lib/rewards";
+import { rankTokens, scoreToken } from "./score";
+import {
+  detectMarketCapMilestones,
+  seedAnnouncedState,
+} from "./milestones";
+import {
+  buildDailyPulseCast,
+  buildMilestoneCast,
+  publishCast,
+  liveCastingEnabled,
+} from "./casts";
+import { polishCastDraft } from "./ai";
+import {
+  NotificationRecord,
+  notifyMilestoneHolders,
+} from "./notifications";
+import * as store from "./store";
+import {
+  CastDraft,
+  CastRecord,
+  PulseRunReport,
+  PulseSnapshot,
+  PulseTokenMetrics,
+} from "./types";
+
+const TRENDING_URL = "https://api.streme.fun/api/tokens/trending?type=all";
+const SNAPSHOT_SIZE = 25;
+const ENRICH_POOL_COUNT = 30;
+const MAX_MILESTONE_CASTS_PER_RUN = 2;
+const DAILY_CAST_HOUR_UTC = 16;
+
+interface UpstreamToken {
+  contract_address?: string;
+  name?: string;
+  symbol?: string;
+  img_url?: string | null;
+  username?: string;
+  staking_pool?: string;
+  timestamp?: { _seconds?: number };
+  lastTraded?: { _seconds?: number };
+  marketData?: {
+    marketCap?: number;
+    price?: number;
+    volume24h?: number;
+    priceChange1h?: number;
+    priceChange24h?: number;
+  };
+}
+
+function toMetrics(token: UpstreamToken, now: number): PulseTokenMetrics | null {
+  const address = token.contract_address?.toLowerCase();
+  if (!address || !token.symbol || !token.name) return null;
+
+  // Upstream marketData is only refreshed for tokens that trade, so "24h"
+  // figures on a token with no trade in 24h are historical leftovers.
+  // Zero them at ingestion so scores, casts, and the page stay honest.
+  const lastTradedAt = token.lastTraded?._seconds ?? 0;
+  const tradedRecently = lastTradedAt > 0 && now - lastTradedAt <= 86400;
+
+  const market = token.marketData ?? {};
+  return {
+    address,
+    name: token.name,
+    symbol: token.symbol.startsWith("$")
+      ? token.symbol.substring(1)
+      : token.symbol,
+    img_url: token.img_url ?? null,
+    username: token.username,
+    createdAt: token.timestamp?._seconds ?? 0,
+    lastTradedAt,
+    marketCap: market.marketCap ?? 0,
+    price: market.price ?? 0,
+    volume24h: tradedRecently ? market.volume24h ?? 0 : 0,
+    change1h: tradedRecently ? market.priceChange1h ?? 0 : 0,
+    change24h: tradedRecently ? market.priceChange24h ?? 0 : 0,
+    stakingPool: token.staking_pool?.toLowerCase(),
+  };
+}
+
+async function fetchTrendingMetrics(now: number): Promise<PulseTokenMetrics[]> {
+  const response = await fetch(TRENDING_URL, {
+    headers: { Accept: "application/json", "User-Agent": "Streme/1.0" },
+    signal: AbortSignal.timeout(15_000),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`Trending API error: ${response.status}`);
+  }
+
+  const tokens: UpstreamToken[] = await response.json();
+  return tokens
+    .filter((t) => {
+      if (t.username && SPAMMER_BLACKLIST.includes(t.username.toLowerCase()))
+        return false;
+      if (
+        t.contract_address &&
+        BLACKLISTED_TOKENS.includes(t.contract_address.toLowerCase())
+      )
+        return false;
+      return true;
+    })
+    .map((t) => toMetrics(t, now))
+    .filter((m): m is PulseTokenMetrics => m !== null);
+}
+
+async function enrichWithPoolStats(
+  metrics: PulseTokenMetrics[]
+): Promise<void> {
+  const pools = metrics
+    .map((m) => m.stakingPool)
+    .filter((p): p is string => Boolean(p));
+  if (pools.length === 0) return;
+
+  const poolData = await fetchBatchPoolData(pools, 1);
+  for (const m of metrics) {
+    const data = m.stakingPool ? poolData[m.stakingPool] : undefined;
+    if (!data) continue;
+    m.totalStakers = parseInt(data.totalMembers) || 0;
+    const flowRate = parseFloat(data.flowRate) || 0;
+    m.rewardFlowPerDay = (flowRate / 1e18) * 86400;
+  }
+}
+
+/** Read-only: fetch, score, enrich, and assemble a snapshot. */
+export async function computeSnapshot(now: number): Promise<PulseSnapshot> {
+  const allMetrics = await fetchTrendingMetrics(now);
+
+  // Pre-rank to bound the subgraph query, enrich the leaders with staking
+  // data, then re-rank so staker counts can influence the final order.
+  const leaders = rankTokens(allMetrics, now, ENRICH_POOL_COUNT);
+  try {
+    await enrichWithPoolStats(leaders);
+  } catch (error) {
+    console.warn("[Pulse] Pool enrichment failed, continuing without:", error);
+  }
+  const tokens = rankTokens(leaders, now, SNAPSHOT_SIZE);
+
+  const totals = {
+    trackedTokens: allMetrics.length,
+    activeTokens24h: allMetrics.filter(
+      (m) => m.lastTradedAt > 0 && now - m.lastTradedAt <= 86400
+    ).length,
+    volume24h: allMetrics.reduce((sum, m) => sum + (m.volume24h || 0), 0),
+    marketCap: allMetrics.reduce((sum, m) => sum + (m.marketCap || 0), 0),
+    launches7d: allMetrics.filter(
+      (m) => m.createdAt > 0 && now - m.createdAt <= 7 * 86400
+    ).length,
+  };
+
+  return { generatedAt: now, tokens, totals };
+}
+
+export interface RunPulseOptions {
+  now?: Date;
+  forceDryRun?: boolean;
+}
+
+export async function runPulse(
+  opts: RunPulseOptions = {}
+): Promise<PulseRunReport> {
+  const startedMs = Date.now();
+  const nowDate = opts.now ?? new Date();
+  const now = Math.floor(nowDate.getTime() / 1000);
+  // forceDryRun is a pure preview: report what a live run would do, but
+  // write no engine state so it can never consume or suppress a real
+  // broadcast. (The snapshot is still refreshed — it's idempotent data.)
+  const persist = !opts.forceDryRun;
+  const errors: string[] = [];
+  const casts: CastRecord[] = [];
+  const notifications: NotificationRecord[] = [];
+  let newMilestones = 0;
+
+  const snapshot = await computeSnapshot(now);
+  await store.setLatestSnapshot(snapshot);
+
+  // --- Milestones ---------------------------------------------------------
+  try {
+    const announced = await store.getAnnouncedThresholds();
+    const allMetrics = snapshot.tokens as PulseTokenMetrics[];
+
+    if (announced === null) {
+      // First ever run: record current levels silently so the bot doesn't
+      // celebrate months-old crossings.
+      if (persist) {
+        await store.setAnnouncedThresholds(seedAnnouncedState(allMetrics));
+      }
+    } else {
+      const milestones = detectMarketCapMilestones(allMetrics, announced, now);
+      newMilestones = milestones.length;
+
+      if (milestones.length > 0) {
+        if (persist) {
+          for (const m of milestones) {
+            announced[m.tokenAddress] = Math.max(
+              announced[m.tokenAddress] ?? 0,
+              m.threshold
+            );
+          }
+          await store.setAnnouncedThresholds(announced);
+          await store.appendMilestones(milestones);
+        }
+
+        const announcedNow = milestones.slice(0, MAX_MILESTONE_CASTS_PER_RUN);
+        for (const milestone of announcedNow) {
+          casts.push(
+            await publishCast(
+              await polishCastDraft(buildMilestoneCast(milestone)),
+              { forceDryRun: opts.forceDryRun, now }
+            )
+          );
+          // Push the same milestone to its holders' devices — the
+          // highest-conversion surface we have.
+          notifications.push(
+            await notifyMilestoneHolders(milestone, {
+              forceDryRun: opts.forceDryRun,
+              now,
+            })
+          );
+        }
+      }
+    }
+  } catch (error) {
+    errors.push(
+      `milestones: ${error instanceof Error ? error.message : "unknown"}`
+    );
+  }
+
+  // --- Daily pulse cast ---------------------------------------------------
+  try {
+    const dateKey = nowDate.toISOString().slice(0, 10);
+    if (
+      nowDate.getUTCHours() >= DAILY_CAST_HOUR_UTC &&
+      !(await store.wasDailyCastHandled(dateKey))
+    ) {
+      const draft = buildDailyPulseCast(snapshot, dateKey);
+      if (draft) {
+        casts.push(
+          await publishCast(await polishCastDraft(draft), {
+            forceDryRun: opts.forceDryRun,
+            now,
+          })
+        );
+      } else {
+        casts.push(skippedRecord(dateKey, now));
+      }
+      if (persist) await store.markDailyCastHandled(dateKey);
+    }
+  } catch (error) {
+    errors.push(
+      `daily_cast: ${error instanceof Error ? error.message : "unknown"}`
+    );
+  }
+
+  if (persist) {
+    await store.appendCastRecords(casts);
+    await store.appendNotificationRecords(notifications);
+  }
+
+  const report: PulseRunReport = {
+    ranAt: now,
+    durationMs: Date.now() - startedMs,
+    tokensTracked: snapshot.totals.trackedTokens,
+    newMilestones,
+    casts,
+    notifications,
+    liveCasting: !opts.forceDryRun && liveCastingEnabled(),
+    errors,
+  };
+
+  await notifySlack(report);
+  return report;
+}
+
+function skippedRecord(dateKey: string, now: number): CastRecord {
+  const draft: CastDraft = {
+    kind: "daily_pulse",
+    idem: `daily_pulse:${dateKey}`,
+    text: "(skipped — 24h activity below quality gate)",
+    embedUrl: "",
+  };
+  return { ...draft, status: "skipped", createdAt: now };
+}
+
+/** Optional ops alerting: post run outcomes to Slack when configured. */
+async function notifySlack(report: PulseRunReport): Promise<void> {
+  const webhook = process.env.PULSE_SLACK_WEBHOOK;
+  if (!webhook) return;
+
+  const published = report.casts.filter((c) => c.status === "published");
+  const failed = report.casts.filter((c) => c.status === "failed");
+  const notifSent = report.notifications.filter((n) => n.status === "sent");
+  const notifFailed = report.notifications.filter((n) => n.status === "failed");
+  if (
+    published.length === 0 &&
+    failed.length === 0 &&
+    notifSent.length === 0 &&
+    notifFailed.length === 0 &&
+    report.errors.length === 0
+  )
+    return;
+
+  const lines = [
+    `Streme Pulse run: ${report.tokensTracked} tokens, ${report.newMilestones} new milestones`,
+    ...published.map((c) => `✅ cast published (${c.kind}): ${c.castHash ?? ""}`),
+    ...failed.map((c) => `❌ cast failed (${c.kind}): ${c.error ?? ""}`),
+    ...notifSent.map(
+      (n) => `🔔 notified ${n.targetCount} holders (${n.milestoneId})`
+    ),
+    ...notifFailed.map(
+      (n) => `❌ notifications failed (${n.milestoneId}): ${n.error ?? ""}`
+    ),
+    ...report.errors.map((e) => `⚠️ ${e}`),
+  ];
+
+  try {
+    await fetch(webhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: lines.join("\n") }),
+      signal: AbortSignal.timeout(5_000),
+    });
+  } catch (error) {
+    console.warn("[Pulse] Slack notification failed:", error);
+  }
+}
+
+// Re-exported so API routes import a single module.
+export { scoreToken };

--- a/src/lib/pulse/format.ts
+++ b/src/lib/pulse/format.ts
@@ -1,0 +1,38 @@
+// Compact number formatting shared by the pulse page, OG card, and casts.
+
+export function formatUsdCompact(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "$0";
+  if (value >= 1_000_000_000)
+    return `$${trimTrailingZero((value / 1_000_000_000).toFixed(1))}B`;
+  if (value >= 1_000_000)
+    return `$${trimTrailingZero((value / 1_000_000).toFixed(1))}M`;
+  if (value >= 1_000)
+    return `$${trimTrailingZero((value / 1_000).toFixed(1))}k`;
+  if (value >= 1) return `$${Math.round(value)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatCountCompact(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value >= 1_000_000)
+    return `${trimTrailingZero((value / 1_000_000).toFixed(1))}M`;
+  if (value >= 1_000) return `${trimTrailingZero((value / 1_000).toFixed(1))}k`;
+  return `${Math.round(value)}`;
+}
+
+export function formatPercentChange(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  const rounded = Math.abs(value) >= 10 ? Math.round(value) : value.toFixed(1);
+  return `${value >= 0 ? "+" : ""}${trimTrailingZero(String(rounded))}%`;
+}
+
+export function formatAge(createdAt: number, now: number): string {
+  const seconds = Math.max(0, now - createdAt);
+  if (seconds < 3600) return `${Math.max(1, Math.floor(seconds / 60))}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function trimTrailingZero(value: string): string {
+  return value.endsWith(".0") ? value.slice(0, -2) : value;
+}

--- a/src/lib/pulse/milestones.ts
+++ b/src/lib/pulse/milestones.ts
@@ -1,0 +1,81 @@
+// Milestone detection — pure functions over snapshot metrics plus a small
+// "already announced" state map, so each threshold fires exactly once per
+// token across the lifetime of the bot.
+
+import { Milestone, PulseTokenMetrics } from "./types";
+
+export const MARKET_CAP_THRESHOLDS = [
+  50_000, 100_000, 250_000, 500_000, 1_000_000, 2_500_000, 5_000_000,
+  10_000_000, 50_000_000, 100_000_000,
+];
+
+// A market cap crossing only counts if the token actually traded recently —
+// stale prices on dead pools can drift across thresholds without any buyer.
+const REQUIRE_TRADE_WITHIN_SECONDS = 24 * 3600;
+
+/** Highest threshold at or below the given market cap (0 if below all). */
+export function highestCrossedThreshold(marketCap: number): number {
+  let crossed = 0;
+  for (const threshold of MARKET_CAP_THRESHOLDS) {
+    if (marketCap >= threshold) crossed = threshold;
+    else break;
+  }
+  return crossed;
+}
+
+/**
+ * Detect new market-cap milestones.
+ *
+ * @param announced map of token address -> highest threshold already announced
+ * @returns at most one milestone per token (the highest newly crossed level)
+ */
+export function detectMarketCapMilestones(
+  tokens: PulseTokenMetrics[],
+  announced: Record<string, number>,
+  now: number
+): Milestone[] {
+  const milestones: Milestone[] = [];
+
+  for (const token of tokens) {
+    const crossed = highestCrossedThreshold(token.marketCap);
+    if (crossed === 0) continue;
+
+    const alreadyAnnounced = announced[token.address] ?? 0;
+    if (crossed <= alreadyAnnounced) continue;
+
+    const tradedRecently =
+      token.lastTradedAt > 0 &&
+      now - token.lastTradedAt <= REQUIRE_TRADE_WITHIN_SECONDS;
+    if (!tradedRecently) continue;
+
+    milestones.push({
+      id: `market_cap:${token.address}:${crossed}`,
+      type: "market_cap",
+      tokenAddress: token.address,
+      symbol: token.symbol,
+      name: token.name,
+      creatorUsername: token.username,
+      threshold: crossed,
+      value: token.marketCap,
+      detectedAt: now,
+    });
+  }
+
+  return milestones.sort((a, b) => b.threshold - a.threshold);
+}
+
+/**
+ * Seed the announced-state map from current metrics without emitting
+ * milestones. Used on the first ever run so the bot doesn't spam a
+ * celebration for every token that crossed a level months ago.
+ */
+export function seedAnnouncedState(
+  tokens: PulseTokenMetrics[]
+): Record<string, number> {
+  const announced: Record<string, number> = {};
+  for (const token of tokens) {
+    const crossed = highestCrossedThreshold(token.marketCap);
+    if (crossed > 0) announced[token.address] = crossed;
+  }
+  return announced;
+}

--- a/src/lib/pulse/notifications.ts
+++ b/src/lib/pulse/notifications.ts
@@ -1,0 +1,188 @@
+// Targeted milestone notifications — "a token you hold just crossed $100k"
+// pushed to the Farcaster users who actually hold it. Far better conversion
+// than any feed post, and fully automated.
+//
+// Delivery modes, best first:
+//   1. Neynar managed notifications (NEYNAR_API_KEY + NEYNAR_CLIENT_ID) —
+//      Neynar holds the notification tokens and fans out per-fid.
+//   2. Self-managed tokens from Redis via sendFrameNotification (fallback).
+// Like casting, sending is gated behind an env flag and dry-runs otherwise.
+
+import { formatUsdCompact } from "./format";
+import { Milestone } from "./types";
+
+const HOLDERS_URL = "https://api.streme.fun/api/stakers";
+const MAX_TARGET_FIDS = 100;
+
+export type NotificationMode = "neynar" | "tokens" | "none";
+
+export interface NotificationRecord {
+  milestoneId: string;
+  title: string;
+  body: string;
+  targetUrl: string;
+  targetCount: number;
+  mode: NotificationMode;
+  status: "dry_run" | "sent" | "failed" | "skipped";
+  error?: string;
+  /** Unix seconds */
+  createdAt: number;
+}
+
+interface HolderDoc {
+  hasFarcaster?: boolean;
+  farcaster?: { fid?: number };
+}
+
+export function notificationsEnabled(): boolean {
+  return process.env.PULSE_NOTIFICATIONS_ENABLED === "true";
+}
+
+function appUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_URL ||
+    "https://streme.fun"
+  );
+}
+
+export function buildMilestoneNotification(milestone: Milestone): {
+  title: string;
+  body: string;
+  targetUrl: string;
+} {
+  return {
+    title: `$${milestone.symbol} crossed ${formatUsdCompact(
+      milestone.threshold
+    )}`,
+    body: `A token you hold just hit ${formatUsdCompact(
+      milestone.threshold
+    )} market cap. Your staking stream keeps flowing — check it out.`,
+    targetUrl: `${appUrl()}/token/${milestone.tokenAddress}`,
+  };
+}
+
+/** Farcaster fids of the token's holders, capped and deduped. */
+export async function fetchHolderFids(tokenAddress: string): Promise<number[]> {
+  const response = await fetch(`${HOLDERS_URL}/${tokenAddress}`, {
+    headers: { Accept: "application/json", "User-Agent": "Streme/1.0" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Holders API error: ${response.status}`);
+  }
+
+  const holders: HolderDoc[] = await response.json();
+  const fids = new Set<number>();
+  for (const holder of holders) {
+    const fid = holder.farcaster?.fid;
+    if (holder.hasFarcaster && typeof fid === "number" && fid > 0) {
+      fids.add(fid);
+    }
+    if (fids.size >= MAX_TARGET_FIDS) break;
+  }
+  return [...fids];
+}
+
+async function sendViaNeynar(
+  fids: number[],
+  notification: { title: string; body: string; targetUrl: string }
+): Promise<void> {
+  const response = await fetch(
+    "https://api.neynar.com/v2/farcaster/frame/notifications",
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": process.env.NEYNAR_API_KEY!,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        target_fids: fids,
+        notification: {
+          title: notification.title,
+          body: notification.body,
+          target_url: notification.targetUrl,
+        },
+      }),
+      signal: AbortSignal.timeout(15_000),
+    }
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Neynar notifications ${response.status}: ${body.slice(0, 200)}`);
+  }
+}
+
+async function sendViaStoredTokens(
+  fids: number[],
+  notification: { title: string; body: string; targetUrl: string }
+): Promise<void> {
+  // Lazy import: notifs.ts pulls in @farcaster/miniapp-sdk (ESM-only),
+  // which we only want loaded when this fallback path actually runs.
+  const { sendFrameNotification } = await import("@/src/lib/notifs");
+  for (const fid of fids) {
+    await sendFrameNotification({
+      fid,
+      title: notification.title,
+      body: notification.body,
+      targetUrl: notification.targetUrl,
+    });
+  }
+}
+
+/**
+ * Notify a milestone token's holders. Never throws — failures become
+ * records, mirroring publishCast.
+ */
+export async function notifyMilestoneHolders(
+  milestone: Milestone,
+  opts: { forceDryRun?: boolean; now?: number } = {}
+): Promise<NotificationRecord> {
+  const createdAt = opts.now ?? Math.floor(Date.now() / 1000);
+  const notification = buildMilestoneNotification(milestone);
+
+  const mode: NotificationMode =
+    process.env.NEYNAR_API_KEY && process.env.NEYNAR_CLIENT_ID
+      ? "neynar"
+      : "tokens";
+
+  const base = {
+    milestoneId: milestone.id,
+    ...notification,
+    mode,
+    createdAt,
+  };
+
+  let fids: number[] = [];
+  try {
+    fids = await fetchHolderFids(milestone.tokenAddress);
+  } catch (error) {
+    return {
+      ...base,
+      targetCount: 0,
+      status: "failed",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+
+  if (fids.length === 0) {
+    return { ...base, targetCount: 0, status: "skipped" };
+  }
+
+  if (opts.forceDryRun || !notificationsEnabled()) {
+    return { ...base, targetCount: fids.length, status: "dry_run" };
+  }
+
+  try {
+    if (mode === "neynar") await sendViaNeynar(fids, notification);
+    else await sendViaStoredTokens(fids, notification);
+    return { ...base, targetCount: fids.length, status: "sent" };
+  } catch (error) {
+    return {
+      ...base,
+      targetCount: fids.length,
+      status: "failed",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/src/lib/pulse/score.ts
+++ b/src/lib/pulse/score.ts
@@ -1,0 +1,104 @@
+// StremeScore — a legible, streaming-native trending score.
+//
+// Every component is bounded and explainable: the final 0-100 score is a
+// weighted blend, and each token carries human-readable `reasons` so the
+// ranking is never a black box (on the /pulse page, in casts, or in logs).
+
+import { PulseToken, PulseTokenMetrics } from "./types";
+import {
+  formatAge,
+  formatCountCompact,
+  formatPercentChange,
+  formatUsdCompact,
+} from "./format";
+
+const WEIGHTS = {
+  volume: 40,
+  momentum24h: 22,
+  momentum1h: 8,
+  freshness: 12,
+  tradeRecency: 8,
+  stakers: 10,
+} as const;
+
+const MAX_SCORE = Object.values(WEIGHTS).reduce((a, b) => a + b, 0);
+
+// Reasons only appear above these floors so quiet tokens don't get
+// padded with noise like "$3 volume".
+const REASON_MIN_VOLUME_USD = 250;
+const REASON_MIN_CHANGE_PCT = 5;
+const REASON_MIN_STAKERS = 25;
+const REASON_MAX_AGE_SECONDS = 72 * 3600;
+
+/** log-scaled 0..1 where `cap` maps to 1 (e.g. $1M daily volume) */
+function logUnit(value: number, cap: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(1, Math.log10(1 + value) / Math.log10(1 + cap));
+}
+
+function clampPct(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(max, Math.max(min, value));
+}
+
+export function scoreToken(
+  m: PulseTokenMetrics,
+  now: number
+): { score: number; reasons: string[] } {
+  const volume = logUnit(m.volume24h, 1_000_000);
+
+  // Momentum: gains help up to +100%, losses drag down to -50%.
+  const momentum24h = clampPct(m.change24h, -50, 100) / 100;
+  const momentum1h = clampPct(m.change1h, -50, 100) / 100;
+
+  // Freshness: linear boost for the first 7 days after launch.
+  const ageSeconds = Math.max(0, now - m.createdAt);
+  const freshness = Math.max(0, 1 - ageSeconds / (7 * 86400));
+
+  // Trade recency: full credit within 24h, fading to 0 over 7 days.
+  const sinceTrade = m.lastTradedAt > 0 ? now - m.lastTradedAt : Infinity;
+  const tradeRecency =
+    sinceTrade <= 86400
+      ? 1
+      : Math.max(0, 1 - (sinceTrade - 86400) / (6 * 86400));
+
+  const stakers = logUnit(m.totalStakers ?? 0, 1_000);
+
+  const raw =
+    volume * WEIGHTS.volume +
+    momentum24h * WEIGHTS.momentum24h +
+    momentum1h * WEIGHTS.momentum1h +
+    freshness * WEIGHTS.freshness +
+    tradeRecency * WEIGHTS.tradeRecency +
+    stakers * WEIGHTS.stakers;
+
+  const score = Math.max(0, Math.min(100, (raw / MAX_SCORE) * 100));
+
+  const reasons: string[] = [];
+  if (m.volume24h >= REASON_MIN_VOLUME_USD) {
+    reasons.push(`${formatUsdCompact(m.volume24h)} 24h volume`);
+  }
+  if (m.change24h >= REASON_MIN_CHANGE_PCT) {
+    reasons.push(`${formatPercentChange(m.change24h)} 24h`);
+  }
+  if (ageSeconds <= REASON_MAX_AGE_SECONDS) {
+    reasons.push(`launched ${formatAge(m.createdAt, now)} ago`);
+  }
+  if ((m.totalStakers ?? 0) >= REASON_MIN_STAKERS) {
+    reasons.push(`${formatCountCompact(m.totalStakers!)} stakers`);
+  }
+
+  return { score: Math.round(score * 10) / 10, reasons };
+}
+
+export function rankTokens(
+  metrics: PulseTokenMetrics[],
+  now: number,
+  limit = 25
+): PulseToken[] {
+  return metrics
+    .map((m) => ({ ...m, ...scoreToken(m, now) }))
+    .sort((a, b) => b.score - a.score || b.volume24h - a.volume24h)
+    .slice(0, limit)
+    .map((t, i) => ({ ...t, rank: i + 1 }));
+}

--- a/src/lib/pulse/store.ts
+++ b/src/lib/pulse/store.ts
@@ -1,0 +1,119 @@
+// Pulse state persistence. Uses Upstash Redis when KV env vars are present
+// (same convention as src/lib/kv.ts), with an in-memory fallback so local
+// dev and tests work with zero configuration.
+
+import { Redis } from "@upstash/redis";
+import { NotificationRecord } from "./notifications";
+import { CastRecord, Milestone, PulseSnapshot } from "./types";
+
+const KEY_PREFIX = "streme:pulse";
+const HISTORY_LIMIT = 50;
+const DAILY_FLAG_TTL_SECONDS = 3 * 86400;
+
+const localStore = new Map<string, unknown>();
+
+const useRedis =
+  process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN;
+const redis = useRedis
+  ? new Redis({
+      url: process.env.KV_REST_API_URL!,
+      token: process.env.KV_REST_API_TOKEN!,
+    })
+  : null;
+
+async function get<T>(key: string): Promise<T | null> {
+  if (redis) return await redis.get<T>(key);
+  return (localStore.get(key) as T) ?? null;
+}
+
+async function set(
+  key: string,
+  value: unknown,
+  ttlSeconds?: number
+): Promise<void> {
+  if (redis) {
+    if (ttlSeconds) await redis.set(key, value, { ex: ttlSeconds });
+    else await redis.set(key, value);
+  } else {
+    localStore.set(key, value);
+  }
+}
+
+export async function getLatestSnapshot(): Promise<PulseSnapshot | null> {
+  return get<PulseSnapshot>(`${KEY_PREFIX}:snapshot`);
+}
+
+export async function setLatestSnapshot(
+  snapshot: PulseSnapshot
+): Promise<void> {
+  await set(`${KEY_PREFIX}:snapshot`, snapshot);
+}
+
+/**
+ * Highest announced market-cap threshold per token address.
+ * Returns null when the engine has never run (callers should seed).
+ */
+export async function getAnnouncedThresholds(): Promise<Record<
+  string,
+  number
+> | null> {
+  return get<Record<string, number>>(`${KEY_PREFIX}:announced`);
+}
+
+export async function setAnnouncedThresholds(
+  announced: Record<string, number>
+): Promise<void> {
+  await set(`${KEY_PREFIX}:announced`, announced);
+}
+
+export async function getRecentMilestones(): Promise<Milestone[]> {
+  return (await get<Milestone[]>(`${KEY_PREFIX}:milestones`)) ?? [];
+}
+
+export async function appendMilestones(
+  milestones: Milestone[]
+): Promise<void> {
+  if (milestones.length === 0) return;
+  const existing = await getRecentMilestones();
+  const merged = [...milestones, ...existing].slice(0, HISTORY_LIMIT);
+  await set(`${KEY_PREFIX}:milestones`, merged);
+}
+
+export async function getRecentCasts(): Promise<CastRecord[]> {
+  return (await get<CastRecord[]>(`${KEY_PREFIX}:casts`)) ?? [];
+}
+
+export async function appendCastRecords(
+  records: CastRecord[]
+): Promise<void> {
+  if (records.length === 0) return;
+  const existing = await getRecentCasts();
+  const merged = [...records, ...existing].slice(0, HISTORY_LIMIT);
+  await set(`${KEY_PREFIX}:casts`, merged);
+}
+
+export async function getRecentNotifications(): Promise<NotificationRecord[]> {
+  return (await get<NotificationRecord[]>(`${KEY_PREFIX}:notifications`)) ?? [];
+}
+
+export async function appendNotificationRecords(
+  records: NotificationRecord[]
+): Promise<void> {
+  if (records.length === 0) return;
+  const existing = await getRecentNotifications();
+  const merged = [...records, ...existing].slice(0, HISTORY_LIMIT);
+  await set(`${KEY_PREFIX}:notifications`, merged);
+}
+
+export async function wasDailyCastHandled(dateKey: string): Promise<boolean> {
+  return (await get<boolean>(`${KEY_PREFIX}:daily:${dateKey}`)) === true;
+}
+
+export async function markDailyCastHandled(dateKey: string): Promise<void> {
+  await set(`${KEY_PREFIX}:daily:${dateKey}`, true, DAILY_FLAG_TTL_SECONDS);
+}
+
+/** Test helper — clears the in-memory fallback store. */
+export function __clearLocalStoreForTests(): void {
+  localStore.clear();
+}

--- a/src/lib/pulse/types.ts
+++ b/src/lib/pulse/types.ts
@@ -1,0 +1,103 @@
+// Streme Pulse — shared types for the automated growth engine.
+// The engine ranks tokens with a legible streaming-native score, detects
+// milestones, and drives the @streme bot's automated casts.
+
+export interface PulseTokenMetrics {
+  /** Lowercase contract address */
+  address: string;
+  name: string;
+  symbol: string;
+  img_url: string | null;
+  username?: string;
+  /** Unix seconds the token launched */
+  createdAt: number;
+  /** Unix seconds of the last recorded trade (0 if unknown) */
+  lastTradedAt: number;
+  marketCap: number;
+  price: number;
+  volume24h: number;
+  change1h: number;
+  change24h: number;
+  /** GDA staking pool address, when known */
+  stakingPool?: string;
+  /** Number of GDA pool members (stakers), from the Superfluid subgraph */
+  totalStakers?: number;
+  /** Reward stream to stakers in tokens/day, from the pool flow rate */
+  rewardFlowPerDay?: number;
+}
+
+export interface PulseToken extends PulseTokenMetrics {
+  rank: number;
+  /** 0-100, see score.ts for the formula */
+  score: number;
+  /** Human-readable reasons this token ranks where it does */
+  reasons: string[];
+}
+
+export interface PulseTotals {
+  trackedTokens: number;
+  /** Tokens with a trade in the last 24h */
+  activeTokens24h: number;
+  volume24h: number;
+  marketCap: number;
+  launches7d: number;
+}
+
+export interface PulseSnapshot {
+  /** Unix seconds */
+  generatedAt: number;
+  tokens: PulseToken[];
+  totals: PulseTotals;
+}
+
+export type MilestoneType = "market_cap";
+
+export interface Milestone {
+  /** `${type}:${address}:${threshold}` — stable id used for dedup */
+  id: string;
+  type: MilestoneType;
+  tokenAddress: string;
+  symbol: string;
+  name: string;
+  /** Farcaster username of the token creator, when known */
+  creatorUsername?: string;
+  threshold: number;
+  /** Metric value when the milestone was detected */
+  value: number;
+  /** Unix seconds */
+  detectedAt: number;
+}
+
+export type CastKind = "daily_pulse" | "milestone";
+
+export interface CastDraft {
+  kind: CastKind;
+  /** Neynar idempotency key (also our dedup key) */
+  idem: string;
+  text: string;
+  embedUrl: string;
+}
+
+export type CastStatus = "dry_run" | "published" | "failed" | "skipped";
+
+export interface CastRecord extends CastDraft {
+  status: CastStatus;
+  castHash?: string;
+  error?: string;
+  /** Unix seconds */
+  createdAt: number;
+}
+
+export interface PulseRunReport {
+  /** Unix seconds */
+  ranAt: number;
+  durationMs: number;
+  tokensTracked: number;
+  newMilestones: number;
+  casts: CastRecord[];
+  /** Holder notifications attempted for new milestones (see notifications.ts) */
+  notifications: import("./notifications").NotificationRecord[];
+  /** Whether live casting was enabled for this run */
+  liveCasting: boolean;
+  errors: string[];
+}

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -104,7 +104,7 @@ async function fetchPoolData(poolId: string, stakingPool: string, retries = 3) {
 }
 
 // Batch fetch multiple pool data in a single GraphQL query for better performance
-async function fetchBatchPoolData(
+export async function fetchBatchPoolData(
   stakingPools: string[],
   retries = 3
 ): Promise<

--- a/src/lib/yield.ts
+++ b/src/lib/yield.ts
@@ -1,0 +1,234 @@
+// Account yield aggregation — the data behind the "flex my stream" cards.
+//
+// For a wallet, reads every Streme GDA pool membership from the Superfluid
+// subgraph, computes the member's share of each reward stream, and decorates
+// the top flows with token metadata + USD rates from the Streme API.
+
+import { BLACKLISTED_TOKENS } from "@/src/lib/blacklist";
+
+const SUBGRAPH_URL =
+  "https://subgraph-endpoints.superfluid.dev/base-mainnet/protocol-v1";
+const TOKENS_MULTIPLE_URL = "https://api.streme.fun/api/tokens/multiple";
+const MAX_FLOWS = 12;
+const SECONDS_PER_DAY = 86400n;
+const WAD = 10n ** 18n;
+
+export interface YieldFlow {
+  tokenAddress: string;
+  symbol: string;
+  name: string;
+  img_url: string | null;
+  /** Reward stream to this wallet, in tokens/day */
+  tokensPerDay: number;
+  /** Same stream valued in USD/day, when a price is known */
+  usdPerDay: number | null;
+  poolId: string;
+  isConnected: boolean;
+}
+
+export interface AccountYield {
+  address: string;
+  /** Total over flows with a known price */
+  totalUsdPerDay: number;
+  /** Number of active reward streams (units > 0) */
+  activeStreams: number;
+  flows: YieldFlow[];
+  /** Unix seconds */
+  generatedAt: number;
+}
+
+interface MembershipNode {
+  units: string;
+  isConnected: boolean;
+  pool: {
+    id: string;
+    flowRate: string;
+    totalUnits: string;
+    token: {
+      id: string;
+      symbol: string;
+      isNativeAssetSuperToken: boolean;
+    };
+  };
+}
+
+interface UpstreamTokenMeta {
+  contract_address?: string;
+  name?: string;
+  symbol?: string;
+  img_url?: string | null;
+  marketData?: { price?: number };
+}
+
+/** flowRate (wei/s) * units / totalUnits → tokens/day, via BigInt. */
+function memberTokensPerDay(
+  flowRate: string,
+  units: string,
+  totalUnits: string
+): number {
+  try {
+    const flow = BigInt(flowRate);
+    const memberUnits = BigInt(units);
+    const total = BigInt(totalUnits);
+    if (flow <= 0n || memberUnits <= 0n || total <= 0n) return 0;
+
+    // Scale by 1e6 before the division so small shares keep precision.
+    const scaled = (flow * SECONDS_PER_DAY * memberUnits * 1_000_000n) / total;
+    return Number(scaled / WAD) / 1_000_000;
+  } catch {
+    return 0;
+  }
+}
+
+async function fetchMemberships(address: string): Promise<MembershipNode[]> {
+  const query = `
+    query AccountYield($accountId: ID!) {
+      account(id: $accountId) {
+        poolMemberships(first: 200) {
+          units
+          isConnected
+          pool {
+            id
+            flowRate
+            totalUnits
+            token {
+              id
+              symbol
+              isNativeAssetSuperToken
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const response = await fetch(SUBGRAPH_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query,
+      variables: { accountId: address.toLowerCase() },
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(`Subgraph error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  if (data.errors) {
+    throw new Error(data.errors[0]?.message || "Subgraph query failed");
+  }
+  return data.data?.account?.poolMemberships ?? [];
+}
+
+async function fetchTokenMeta(
+  addresses: string[]
+): Promise<Record<string, UpstreamTokenMeta>> {
+  if (addresses.length === 0) return {};
+  try {
+    const response = await fetch(TOKENS_MULTIPLE_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tokenAddresses: addresses.slice(0, 30) }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return {};
+    const payload = await response.json();
+    const tokens: UpstreamTokenMeta[] = Array.isArray(payload)
+      ? payload
+      : payload?.data ?? [];
+    const byAddress: Record<string, UpstreamTokenMeta> = {};
+    for (const token of tokens) {
+      if (token?.contract_address) {
+        byAddress[token.contract_address.toLowerCase()] = token;
+      }
+    }
+    return byAddress;
+  } catch {
+    return {};
+  }
+}
+
+export async function getAccountYield(address: string): Promise<AccountYield> {
+  const normalized = address.toLowerCase();
+  const memberships = await fetchMemberships(normalized);
+
+  const active = memberships.filter((m) => {
+    if (!m.units || parseFloat(m.units) <= 0) return false;
+    if (m.pool.token.isNativeAssetSuperToken) return false;
+    if (BLACKLISTED_TOKENS.includes(m.pool.token.id.toLowerCase()))
+      return false;
+    return true;
+  });
+
+  // A wallet can be in several reward pools for the same token (e.g. v1 +
+  // migrated staking pools) — aggregate per token so it appears once.
+  const byToken = new Map<
+    string,
+    {
+      tokenAddress: string;
+      symbol: string;
+      poolId: string;
+      isConnected: boolean;
+      tokensPerDay: number;
+    }
+  >();
+  for (const m of active) {
+    const tokensPerDay = memberTokensPerDay(
+      m.pool.flowRate,
+      m.units,
+      m.pool.totalUnits
+    );
+    if (tokensPerDay <= 0) continue;
+
+    const tokenAddress = m.pool.token.id.toLowerCase();
+    const existing = byToken.get(tokenAddress);
+    if (existing) {
+      existing.tokensPerDay += tokensPerDay;
+      existing.isConnected = existing.isConnected || m.isConnected;
+    } else {
+      byToken.set(tokenAddress, {
+        tokenAddress,
+        symbol: m.pool.token.symbol.replace(/^\$/, ""),
+        poolId: m.pool.id.toLowerCase(),
+        isConnected: m.isConnected,
+        tokensPerDay,
+      });
+    }
+  }
+
+  const flowsRaw = [...byToken.values()]
+    .sort((a, b) => b.tokensPerDay - a.tokensPerDay)
+    .slice(0, MAX_FLOWS);
+
+  const meta = await fetchTokenMeta(flowsRaw.map((f) => f.tokenAddress));
+
+  const flows: YieldFlow[] = flowsRaw
+    .map((f) => {
+      const m = meta[f.tokenAddress];
+      const price = m?.marketData?.price;
+      return {
+        ...f,
+        name: m?.name ?? f.symbol,
+        img_url: m?.img_url ?? null,
+        usdPerDay:
+          typeof price === "number" && price > 0
+            ? f.tokensPerDay * price
+            : null,
+      };
+    })
+    .sort(
+      (a, b) =>
+        (b.usdPerDay ?? 0) - (a.usdPerDay ?? 0) ||
+        b.tokensPerDay - a.tokensPerDay
+    );
+
+  return {
+    address: normalized,
+    totalUsdPerDay: flows.reduce((sum, f) => sum + (f.usdPerDay ?? 0), 0),
+    activeStreams: flows.length,
+    flows,
+    generatedAt: Math.floor(Date.now() / 1000),
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
   "buildCommand": "next build",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "crons": [
+    {
+      "path": "/api/cron/pulse",
+      "schedule": "*/30 * * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Streme's unique primitive — tokens that stream staking rewards by the second — had no distribution loops: trending was a plain volume sort from the backend, milestones passed silently, nothing in this repo ran on a schedule, and there was no programmatic way for an agent to use the platform (todos/013). This PR adds three connected systems that turn the primitive into growth loops, all automation-first and safe-by-default:

| Ship | What's now possible | Surfaces |
|---|---|---|
| **Streme Pulse** | A cron engine ranks every token with a transparent score (volume, momentum, freshness, trade recency, stakers — each token carries human-readable reasons), detects market-cap milestone crossings, and broadcasts from @streme: daily pulse casts, milestone celebrations that @mention the creator, and push notifications to that token's Farcaster-connected holders | `/pulse`, `/api/pulse`, `/api/cron/pulse` (every 30 min), dynamic OG card |
| **Yield flex cards** | Any wallet's live reward streams on a public, shareable page — per-second animated counter, USD/day, one-tap cast composer, dynamic OG card with Farcaster identity. Every staker who shares becomes an ad for the streaming primitive | `/yield/[address]` (+OG image), "Share My Stream" on My Tokens |
| **Agent gateway** | Any MCP-capable agent (Claude, Cursor, frameworks) adds one URL and can discover tokens, read the pulse, check wallet yield, and build transactions: buy+auto-stake (live quote), stake, unstake, connect-pool, per-second streams | `/api/mcp` (10 tools), REST under `/api/agent/*`, `/llms.txt`, `/agents` |

## Design decisions

- **Nothing goes live by accident.** Casting, notifications, and AI copy are each gated behind their own env flag and dry-run otherwise; every broadcast (made or skipped) is logged to the `/pulse` activity feed. `GET /api/cron/pulse?dry=1&at=<ISO>` is a zero-write time-travel preview — it reports exactly what a live run at that moment would do without consuming milestone state or the daily-cast slot. Without `CRON_SECRET`, the cron route can only dry-run.
- **Honest data over impressive data.** Upstream `marketData` is only refreshed for tokens that trade, so a token idle since December still "claims" its old 24h volume. The engine zeroes 24h stats for any token without a trade in 24h, and quality gates skip the daily cast entirely rather than brag about a quiet tape. Milestones require a trade within 24h and seed silently on first run so the bot never celebrates months-old crossings.
- **Custody model: unsigned transactions only.** Every gateway tx endpoint returns `{description, tx: {to, data, value?, chainId: 8453}, notes}` for the agent's own wallet to sign — the same calldata the UI buttons produce (zap with live Uniswap/Aerodrome quote + slippage, single ERC777 `send()` to the StakingHelper with no approval step, CFA `setFlowrate`). Streme never holds keys, which is why the surface needs no auth.
- **AI that can't hallucinate a stat.** Optional Claude-written cast copy (`PULSE_AI_COPY=true`) runs through a validator that requires every number, dollar figure, percentage, ticker, and @mention from the template to survive verbatim — any violation falls back to the template. The bot gets wittier as models improve; the facts are pinned.
- **State degrades gracefully.** Pulse/milestone state uses the existing Upstash Redis convention with an in-memory fallback, so local dev and preview deployments work with zero configuration, and `/api/pulse` recomputes a read-only snapshot when state is cold.

## Activation

Deploy = shadow mode (everything dry-run, observable on `/pulse`). Then per loop: `CRON_SECRET` (authenticates the Vercel cron), `PULSE_CASTS_ENABLED=true` + `STREME_SIGNER_UUID` (live casting via existing `NEYNAR_API_KEY`), `PULSE_NOTIFICATIONS_ENABLED=true` (holder pushes), `PULSE_AI_COPY=true` (Claude copy), `PULSE_SLACK_WEBHOOK` (ops alerts).

## Verification

35 new unit tests (scoring, milestone dedup/seeding, cast building + byte-safe trimming, notification targeting, AI validation, and calldata round-trip decodes for every tx builder). Exercised live against Base mainnet: MCP initialize/tools-list/tools-call, buy quote through the real Uniswap quoter, yield for a real staker wallet (surfaced and fixed per-token pool aggregation), `/pulse` and `/yield` verified visually on mobile + desktop. `check:all` and production build green; the only failing repo test (`priceUtils`) predates this branch (stale expectation from ae0eb74). New deps: `@anthropic-ai/sdk`, `mcp-handler`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5_%281M%29-D97757?logo=claude&logoColor=white)
