### PR TITLE
feat(skate): Streme Skate — neon endless-skater mini-app at /skate

### DIFF
--- a/src/app/api/skate/ghosts/route.ts
+++ b/src/app/api/skate/ghosts/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, Errors } from "@farcaster/quick-auth";
+import { getGhosts, saveGhost } from "../../../../lib/skateGhosts";
+
+const MAX_SCORE = 100_000_000;
+
+async function authenticateFid(request: NextRequest): Promise<number | null> {
+  if (process.env.NODE_ENV !== "production") {
+    const devFid = Number(request.headers.get("x-dev-fid"));
+    if (Number.isInteger(devFid) && devFid > 0) return devFid;
+  }
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  const token = authHeader.substring(7);
+  try {
+    const client = createClient();
+    const payload = await client.verifyJwt({
+      token,
+      domain: request.headers.get("host") || "streme.fun",
+    });
+    const fid = Number(payload.sub);
+    return Number.isInteger(fid) && fid > 0 ? fid : null;
+  } catch (e) {
+    if (e instanceof Errors.InvalidTokenError) return null;
+    throw e;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const fidParam = Number(searchParams.get("fid"));
+    const excludeFid =
+      Number.isInteger(fidParam) && fidParam > 0 ? fidParam : undefined;
+    const limitParam = Number(searchParams.get("limit"));
+    const limit =
+      Number.isInteger(limitParam) && limitParam > 0 && limitParam <= 5
+        ? limitParam
+        : 4;
+    const ghosts = await getGhosts(limit, excludeFid);
+    return NextResponse.json(
+      { ghosts },
+      { headers: { "Cache-Control": "public, s-maxage=10, stale-while-revalidate=60" } }
+    );
+  } catch (error) {
+    console.error("Skate ghosts GET error:", error);
+    return NextResponse.json({ error: "Failed to load ghosts" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const fid = await authenticateFid(request);
+    if (!fid) {
+      return NextResponse.json({ error: "Authorization required" }, { status: 401 });
+    }
+    const body = (await request.json()) as {
+      score?: unknown;
+      username?: unknown;
+      samples?: unknown;
+    };
+    const score = Math.floor(Number(body.score));
+    if (!Number.isFinite(score) || score <= 0 || score > MAX_SCORE) {
+      return NextResponse.json({ error: "Invalid score" }, { status: 400 });
+    }
+    if (!Array.isArray(body.samples)) {
+      return NextResponse.json({ error: "Invalid samples" }, { status: 400 });
+    }
+    const samples = body.samples
+      .slice(0, 1400)
+      .map((n) => Number(n))
+      .filter((n) => Number.isFinite(n));
+    const username =
+      typeof body.username === "string" ? body.username.slice(0, 32) : "";
+
+    await saveGhost({ fid, username, score, samples });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("Skate ghosts POST error:", error);
+    return NextResponse.json({ error: "Failed to save ghost" }, { status: 500 });
+  }
+}

--- a/src/app/api/skate/image/route.tsx
+++ b/src/app/api/skate/image/route.tsx
@@ -1,0 +1,226 @@
+// Dynamic OG card for /skate — when a player shares their run, the cast embed
+// itself shows their score and dares friends to beat it.
+
+import { ImageResponse } from "next/og";
+import { NextRequest } from "next/server";
+import { SKATE_DISPLAY_URL } from "../../../../lib/skateShare";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const host = request.headers.get("host");
+  const protocol = host?.includes("localhost") ? "http" : "https";
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || `${protocol}://${host}`;
+
+  const { searchParams } = new URL(request.url);
+  const scoreParam = Number(searchParams.get("s"));
+  const score =
+    Number.isFinite(scoreParam) && scoreParam > 0
+      ? Math.min(Math.floor(scoreParam), 100_000_000)
+      : null;
+  const byRaw = searchParams.get("by") ?? "";
+  const by = /^[a-z0-9_.-]{1,32}$/i.test(byRaw) ? byRaw : null;
+  const rankParam = Number(searchParams.get("r"));
+  const rank =
+    Number.isInteger(rankParam) && rankParam > 0 && rankParam <= 10_000
+      ? rankParam
+      : null;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          // Synthwave night: deep indigo sky melting into a hot horizon
+          background:
+            "linear-gradient(180deg, #0c0626 0%, #221060 42%, #6d1f9e 60%, #ec4899 74%, #2b1854 100%)",
+          fontFamily: "sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Neon street floor (Satori-safe: no 3D transforms / repeating gradients) */}
+        <div
+          style={{
+            display: "flex",
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: 210,
+            background:
+              "linear-gradient(180deg, #1a0d3e 0%, #0a0520 100%)",
+          }}
+        />
+        {/* Glowing waterline / street edge */}
+        <div
+          style={{
+            display: "flex",
+            position: "absolute",
+            left: 0,
+            right: 0,
+            bottom: 210,
+            height: 4,
+            background: "#2dd4bf",
+          }}
+        />
+        {/* A few receding neon grid lines */}
+        {[40, 90, 150].map((b) => (
+          <div
+            key={b}
+            style={{
+              display: "flex",
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: b,
+              height: 2,
+              background: "rgba(45,212,191,0.28)",
+            }}
+          />
+        ))}
+        {/* Synthwave sun on the horizon */}
+        <div
+          style={{
+            position: "absolute",
+            top: 120,
+            left: 470,
+            width: 260,
+            height: 260,
+            borderRadius: "50%",
+            background:
+              "linear-gradient(180deg, #fde68a 0%, #fb923c 40%, #ec4899 70%, #a855f7 100%)",
+            opacity: 0.85,
+          }}
+        />
+
+        <div
+          style={{
+            position: "relative",
+            zIndex: 1,
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "60px 80px",
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div
+              style={{
+                display: "flex",
+                fontSize: 44,
+                fontWeight: 800,
+                letterSpacing: 4,
+                color: "#67e8f9",
+                textShadow: "0 0 18px rgba(103,232,249,0.9)",
+              }}
+            >
+              STREME SKATE
+            </div>
+            {score ? (
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 138,
+                    fontWeight: 800,
+                    color: "#ffffff",
+                    lineHeight: 1.02,
+                    textShadow: "0 0 26px rgba(236,72,153,0.8)",
+                  }}
+                >
+                  {score.toLocaleString()}
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 40,
+                    color: "#f5d0fe",
+                    marginTop: 6,
+                  }}
+                >
+                  {by ? `@${by} dares you to beat it` : "Can you beat this line?"}
+                </div>
+                {rank && (
+                  <div
+                    style={{
+                      display: "flex",
+                      alignSelf: "flex-start",
+                      marginTop: 18,
+                      padding: "10px 26px",
+                      borderRadius: 999,
+                      background: "rgba(103, 232, 249, 0.15)",
+                      border: "2px solid #67e8f9",
+                      fontSize: 34,
+                      fontWeight: 700,
+                      color: "#67e8f9",
+                    }}
+                  >
+                    #{rank} on the leaderboard
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 80,
+                    fontWeight: 800,
+                    color: "#ffffff",
+                    lineHeight: 1.1,
+                  }}
+                >
+                  Grind the stream
+                </div>
+                <div
+                  style={{
+                    display: "flex",
+                    fontSize: 38,
+                    color: "#f5d0fe",
+                    marginTop: 10,
+                  }}
+                >
+                  Ollie · flip · grind · stack combos
+                </div>
+              </div>
+            )}
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                marginTop: 24,
+                fontSize: 30,
+                color: "#c4b5fd",
+              }}
+            >
+              <div style={{ display: "flex", width: 26, height: 10, background: "#6366f1", borderRadius: 4 }} />
+              <div style={{ display: "flex", width: 26, height: 10, background: "#ec4899", borderRadius: 4 }} />
+              <div style={{ display: "flex", width: 26, height: 10, background: "#2dd4bf", borderRadius: 4 }} />
+              {SKATE_DISPLAY_URL}
+            </div>
+          </div>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={`${baseUrl}/surf/monster.png`}
+            width={360}
+            height={360}
+            alt=""
+            style={{ transform: "rotate(-12deg)" }}
+          />
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 800 }
+  );
+}

--- a/src/app/api/skate/leaderboard/route.ts
+++ b/src/app/api/skate/leaderboard/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, Errors } from "@farcaster/quick-auth";
+import {
+  getSkateLeaderboard,
+  submitSkateScore,
+} from "../../../../lib/skateLeaderboard";
+
+const MAX_SCORE = 100_000_000;
+const MAX_COMBO = 50_000_000;
+
+/**
+ * Resolve the caller's fid: Quick Auth JWT in production, with an
+ * x-dev-fid header escape hatch for local development only.
+ */
+async function authenticateFid(request: NextRequest): Promise<number | null> {
+  if (process.env.NODE_ENV !== "production") {
+    const devFid = Number(request.headers.get("x-dev-fid"));
+    if (Number.isInteger(devFid) && devFid > 0) return devFid;
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  const token = authHeader.substring(7);
+
+  try {
+    const client = createClient();
+    const payload = await client.verifyJwt({
+      token,
+      domain: request.headers.get("host") || "streme.fun",
+    });
+    const fid = Number(payload.sub);
+    return Number.isInteger(fid) && fid > 0 ? fid : null;
+  } catch (e) {
+    if (e instanceof Errors.InvalidTokenError) return null;
+    throw e;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const fidParam = Number(searchParams.get("fid"));
+    const fid =
+      Number.isInteger(fidParam) && fidParam > 0 ? fidParam : undefined;
+    const data = await getSkateLeaderboard(10, fid);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=15, stale-while-revalidate=60",
+      },
+    });
+  } catch (error) {
+    console.error("Skate leaderboard GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to load leaderboard" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const fid = await authenticateFid(request);
+    if (!fid) {
+      return NextResponse.json(
+        { error: "Authorization required" },
+        { status: 401 }
+      );
+    }
+
+    const body = (await request.json()) as {
+      score?: unknown;
+      combo?: unknown;
+      username?: unknown;
+      pfpUrl?: unknown;
+    };
+
+    const score = Math.floor(Number(body.score));
+    if (!Number.isFinite(score) || score <= 0 || score > MAX_SCORE) {
+      return NextResponse.json({ error: "Invalid score" }, { status: 400 });
+    }
+    const combo = Math.min(
+      Math.max(Math.floor(Number(body.combo)) || 0, 0),
+      MAX_COMBO
+    );
+    const username =
+      typeof body.username === "string" ? body.username.slice(0, 32) : "";
+    const pfpUrl =
+      typeof body.pfpUrl === "string" && body.pfpUrl.startsWith("https://")
+        ? body.pfpUrl.slice(0, 300)
+        : "";
+
+    const result = await submitSkateScore({
+      fid,
+      username,
+      pfpUrl,
+      score,
+      combo,
+    });
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Skate leaderboard POST error:", error);
+    return NextResponse.json(
+      { error: "Failed to submit score" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/skate/warplet-image/route.ts
+++ b/src/app/api/skate/warplet-image/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getWarpletImageUri } from "../../../../lib/warplets";
+
+// Same-origin proxy for a Warplet's on-chain IPFS image so the game <canvas>
+// can use it without tainting (and so <img> thumbnails work everywhere).
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const token = searchParams.get("token") || "";
+    if (!/^\d{1,20}$/.test(token)) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    }
+    const imageUrl = await getWarpletImageUri(BigInt(token));
+    if (!imageUrl) {
+      return NextResponse.json({ error: "No image" }, { status: 404 });
+    }
+    const res = await fetch(imageUrl, {
+      headers: { Accept: "image/*" },
+      // gateways can be slow; let Next cache the result
+      next: { revalidate: 86400 },
+    });
+    if (!res.ok) {
+      return NextResponse.json({ error: "Fetch failed" }, { status: 502 });
+    }
+    const contentType = res.headers.get("content-type") || "image/png";
+    const body = await res.arrayBuffer();
+    return new NextResponse(body, {
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=86400, s-maxage=604800, immutable",
+      },
+    });
+  } catch (error) {
+    console.error("Warplet image error:", error);
+    return NextResponse.json({ error: "Failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/skate/warplets/route.ts
+++ b/src/app/api/skate/warplets/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getWarpletEligibility } from "../../../../lib/warplets";
+
+const ADDR_RE = /^0x[a-fA-F0-9]{40}$/;
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const address = searchParams.get("address") || "";
+    if (!ADDR_RE.test(address)) {
+      return NextResponse.json({ error: "Invalid address" }, { status: 400 });
+    }
+    const data = await getWarpletEligibility(address);
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
+      },
+    });
+  } catch (error) {
+    console.error("Warplets GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to check warplets" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/skate/SkatePageClient.tsx
+++ b/src/app/skate/SkatePageClient.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useAppFrameLogic } from "../../hooks/useAppFrameLogic";
+import type { SkateChallenge } from "../../components/skate/StremeSkateGame";
+
+const StremeSkateGame = dynamic(
+  () => import("../../components/skate/StremeSkateGame"),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="flex h-full w-full items-center justify-center"
+        style={{
+          background:
+            "linear-gradient(180deg, #0c0626 0%, #221060 55%, #45179b 100%)",
+        }}
+      >
+        <span className="loading loading-spinner loading-lg text-white" />
+      </div>
+    ),
+  }
+);
+
+export default function SkatePageClient({
+  challenge,
+}: {
+  challenge?: SkateChallenge | null;
+}) {
+  const { isMiniAppView } = useAppFrameLogic();
+
+  // Full-bleed within ClientLayout's px-4 main. Mini-app reserves 5rem for the
+  // bottom navbar (main's pb-20); browser reserves 4.5rem for the fixed top
+  // navbar (h-18).
+  return (
+    <div
+      className="-mx-4 relative overflow-hidden"
+      style={
+        isMiniAppView
+          ? { height: "calc(100dvh - 5rem)" }
+          : { height: "calc(100dvh - 4.5rem)", marginTop: "4.5rem" }
+      }
+    >
+      <StremeSkateGame challenge={challenge} />
+    </div>
+  );
+}

--- a/src/app/skate/page.tsx
+++ b/src/app/skate/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import SkatePageClient from "./SkatePageClient";
+
+const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
+
+interface Props {
+  searchParams: Promise<{ s?: string; by?: string; r?: string }>;
+}
+
+function parseChallenge(params: { s?: string; by?: string; r?: string }) {
+  const score = Number(params.s);
+  if (!Number.isFinite(score) || score <= 0 || score > 100_000_000) {
+    return null;
+  }
+  const by =
+    typeof params.by === "string" && /^[a-z0-9_.-]{1,32}$/i.test(params.by)
+      ? params.by
+      : undefined;
+  const rank = Number(params.r);
+  return {
+    score: Math.floor(score),
+    by,
+    rank: Number.isInteger(rank) && rank > 0 ? rank : undefined,
+  };
+}
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const challenge = parseChallenge(await searchParams);
+
+  const title = "Streme Skate - Grind the Stream";
+  const description = challenge
+    ? `Someone${
+        challenge.by ? ` (@${challenge.by})` : ""
+      } scored ${challenge.score.toLocaleString()} in Streme Skate. Think you can beat it?`
+    : "A neon, GBA-style skate trick-attack. Ollie ramps, flip in the air, grind the streams, and stack combos. How high can you score?";
+
+  const imageParams = new URLSearchParams();
+  if (challenge) {
+    imageParams.set("s", String(challenge.score));
+    if (challenge.by) imageParams.set("by", challenge.by);
+    if (challenge.rank) imageParams.set("r", String(challenge.rank));
+  }
+  const imageUrl = `${baseUrl}/api/skate/image${
+    imageParams.size > 0 ? `?${imageParams.toString()}` : ""
+  }`;
+
+  const pageParams = new URLSearchParams();
+  if (challenge) {
+    pageParams.set("s", String(challenge.score));
+    if (challenge.by) pageParams.set("by", challenge.by);
+  }
+  const pageUrl = `${baseUrl}/skate${
+    pageParams.size > 0 ? `?${pageParams.toString()}` : ""
+  }`;
+
+  const frameEmbed = {
+    version: "next",
+    imageUrl,
+    button: {
+      title: challenge
+        ? `🛹 Beat ${challenge.score.toLocaleString()}`
+        : "🛹 Play Streme Skate",
+      action: {
+        type: "launch_frame",
+        name: "Streme",
+        url: pageUrl,
+        splashImageUrl: `${baseUrl}/icon.png`,
+        splashBackgroundColor: "#0c0626",
+      },
+    },
+  };
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [imageUrl],
+    },
+    other: {
+      "fc:frame": JSON.stringify(frameEmbed),
+    },
+  };
+}
+
+export default async function SkatePage({ searchParams }: Props) {
+  const challenge = parseChallenge(await searchParams);
+  return <SkatePageClient challenge={challenge} />;
+}

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -46,6 +46,7 @@ export interface SkateResult {
   tricks: number;
   distance: number;
   finished: boolean; // always false — endless run, you go till you wipe out
+  timedOut: boolean; // ran the countdown clock to zero (vs. wiped out in a pit)
 }
 
 export interface SkateCallbacks {
@@ -56,6 +57,8 @@ export interface SkateCallbacks {
   onZone?: (name: string, index: number, accent: string) => void;
   onLives?: (lives: number) => void;
   onGrindTick?: (level: number) => void; // rising grind audio (seconds on the rail)
+  onTime?: (seconds: number) => void; // countdown clock remaining
+  onTimeBonus?: (amount: number) => void; // recharge pop (+X.Xs)
   onCombo?: (info: ComboInfo | null) => void;
   onBank?: (amount: number) => void;
   onBail?: (lostCombo: number) => void;
@@ -140,6 +143,12 @@ const METRES = 9;
 const GRIND_BASE = 16; // base points per 50px of rail at multiplier 1
 const GRIND_RAMP = 1.5; // multiplier growth per second on the rail
 const COYOTE = 0.1; // grace window to still jump after rolling off an edge (Celeste)
+
+// run timer — drains in real time (a touch faster as it gets harder), and
+// RECHARGES when you pull off something great (Crazy Taxi / OutRun urgency).
+// Hitting zero ends the run, so you must keep skating well, not just survive.
+const START_TIME = 18; // seconds on the clock at drop-in
+const TIME_CAP = 26; // most time you can ever bank
 
 const SPIN_MAX = 13; // rad/s when flipping
 const SPIN_ACCEL = 46;
@@ -335,6 +344,10 @@ export class SkateGameEngine {
   private magnetT = 0;
   private rocketT = 0;
 
+  // run timer
+  private timeLeft = START_TIME;
+  private lastTimeSent = -1;
+
   // visuals
   private boardRot = 0;
   private crashT = 0;
@@ -445,6 +458,7 @@ export class SkateGameEngine {
         this.shake = 0.4;
         this.flashT = 0.2;
         this.emitCombo();
+        this.addTime(2);
       }
       this.vy = RAIL_POP;
       this.state = "airborne";
@@ -544,6 +558,8 @@ export class SkateGameEngine {
     this.flowT = 0;
     this.magnetT = 0;
     this.rocketT = 0;
+    this.timeLeft = START_TIME;
+    this.lastTimeSent = -1;
     this.boardRot = 0;
     this.crashT = 0;
     this.shake = 0;
@@ -557,6 +573,7 @@ export class SkateGameEngine {
     this.cb.onProgress?.(0);
     this.cb.onZone?.(ZONES[0].name, 0, ZONES[0].accent);
     this.cb.onLives?.(this.lives);
+    this.cb.onTime?.(this.timeLeft);
     this.cb.onCombo?.(null);
     this.cb.onSpecial?.(0);
     this.cb.onFlow?.(false);
@@ -656,6 +673,22 @@ export class SkateGameEngine {
   private addScore(points: number) {
     this.bankedPoints += points;
     this.refreshScore();
+  }
+
+  /** Recharge the run clock for a great play (clamped, fires a +Xs pop). */
+  private addTime(sec: number) {
+    if (this.state === "over" || sec <= 0) return;
+    this.timeLeft = Math.min(TIME_CAP, this.timeLeft + sec);
+    this.cb.onTimeBonus?.(sec);
+    this.emitTime();
+  }
+
+  private emitTime() {
+    const v = Math.max(0, this.timeLeft);
+    if (Math.abs(v - this.lastTimeSent) >= 0.1 || (v === 0 && this.lastTimeSent !== 0)) {
+      this.lastTimeSent = v;
+      this.cb.onTime?.(v);
+    }
   }
 
   private refreshScore() {
@@ -1181,6 +1214,7 @@ export class SkateGameEngine {
         this.cb.onCallout?.("LOOP!", "combo");
         this.flashT = 0.3;
         this.sfx("perfect");
+        this.addTime(3);
       }
       this.advanceVisuals(dt, 0);
       return;
@@ -1214,6 +1248,18 @@ export class SkateGameEngine {
     }
     this.refreshScore();
 
+    // ---- countdown clock: drains in real time (faster as it gets harder),
+    //      recharged by great plays. Zero = the run is over.
+    this.timeLeft -= (1 + this.difficulty() * 0.35) * dt;
+    if (this.timeLeft <= 0) {
+      this.timeLeft = 0;
+      this.emitTime();
+      this.cb.onCallout?.("TIME UP!", "sloppy");
+      this.gameOver(false, true);
+      return;
+    }
+    this.emitTime();
+
     // ---- endless progress: a looping bar that fills across each zone, plus a
     //      name callout when a new biome begins
     const zp = this.px / ZONE_LEN;
@@ -1233,9 +1279,9 @@ export class SkateGameEngine {
       }
     }
 
-    // enter a Sonic loop when we reach its centre (grounded, not in a rocket).
-    // Triggering at the centre — where we also exit — keeps entry/exit smooth.
-    if (this.state === "running" && this.py < 12 && this.rocketT <= 0) {
+    // enter a Sonic loop when we reach its centre (grounded). Triggering at the
+    // centre — where we also exit — keeps entry/exit smooth.
+    if (this.state === "running" && this.py < 12) {
       const loop = this.loops.find(
         (l) => !l.done && this.px >= l.x + l.r - 30 && this.px <= l.x + l.r + 30
       );
@@ -1252,36 +1298,32 @@ export class SkateGameEngine {
     }
 
     if (this.state === "running") {
-      if (this.rocketT > 0) {
+      // turbo (rocket) is pure speed now — you still ride ramps and fall in pits
+      const ramp = this.rampAt(this.px);
+      if (ramp) {
+        // riding up the ramp face
+        this.rampUnder = ramp;
+        this.py = this.rampSurface(ramp, this.px);
+        const slope =
+          (this.rampSurface(ramp, this.px + 5) -
+            this.rampSurface(ramp, this.px - 5)) /
+          10;
+        this.boardRot = -Math.atan(slope);
+      } else if (this.overGap(this.px)) {
+        this.rampUnder = null;
+        this.state = "airborne";
+        this.vy = -40;
+        this.coyoteT = COYOTE; // brief grace to still pop a jump after the edge
+      } else if (this.rampUnder && this.px < this.rampUnder.xLip + 90) {
+        // crossed the lip (even if a fast frame skipped the exact window) —
+        // launch up + forward instead of snapping straight down to the street
+        const r = this.rampUnder;
+        this.rampUnder = null;
+        this.launchFromRamp(r);
+      } else {
+        this.rampUnder = null;
         this.py = 0;
         this.boardRot *= Math.max(0, 1 - dt * 12);
-      } else {
-        const ramp = this.rampAt(this.px);
-        if (ramp) {
-          // riding up the ramp face
-          this.rampUnder = ramp;
-          this.py = this.rampSurface(ramp, this.px);
-          const slope =
-            (this.rampSurface(ramp, this.px + 5) -
-              this.rampSurface(ramp, this.px - 5)) /
-            10;
-          this.boardRot = -Math.atan(slope);
-        } else if (this.overGap(this.px)) {
-          this.rampUnder = null;
-          this.state = "airborne";
-          this.vy = -40;
-          this.coyoteT = COYOTE; // brief grace to still pop a jump after the edge
-        } else if (this.rampUnder && this.px < this.rampUnder.xLip + 90) {
-          // crossed the lip (even if a fast frame skipped the exact window) —
-          // launch up + forward instead of snapping straight down to the street
-          const r = this.rampUnder;
-          this.rampUnder = null;
-          this.launchFromRamp(r);
-        } else {
-          this.rampUnder = null;
-          this.py = 0;
-          this.boardRot *= Math.max(0, 1 - dt * 12);
-        }
       }
     } else if (this.state === "airborne") {
       if (this.coyoteT > 0) this.coyoteT = Math.max(0, this.coyoteT - dt);
@@ -1311,7 +1353,7 @@ export class SkateGameEngine {
         this.boardRot += (target - this.boardRot) * Math.min(dt * 11, 1);
       }
 
-      if (this.vy <= 40 && this.rocketT <= 0) {
+      if (this.vy <= 40) {
         const rail = this.railCaptureAt(this.px, this.py);
         if (rail) {
           this.currentRail = rail;
@@ -1333,7 +1375,7 @@ export class SkateGameEngine {
       if (this.state === "airborne" && this.vy <= 0) {
         const surf = this.surfaceAt(this.px);
         if (Number.isNaN(surf)) {
-          if (this.py <= -10 && this.rocketT <= 0) this.crash();
+          if (this.py <= -10) this.crash();
         } else if (this.py <= surf) {
           this.resolveLanding(surf);
         }
@@ -1444,9 +1486,11 @@ export class SkateGameEngine {
         this.shake = 0.7;
         this.hitstop = 0.05;
         this.flashT = 0.25;
+        this.addTime(2.5); // a stomped flip buys you serious time
       } else {
         this.sfx("land");
         this.shake = 0.3;
+        this.addTime(1.4);
       }
       this.landBurst(banked > 800 ? 16 : 9, C_GOLD);
     } else if (off < 0.95) {
@@ -1458,6 +1502,7 @@ export class SkateGameEngine {
       this.sfx("land");
       this.shake = 0.35;
       this.landBurst(8, C_CYAN);
+      this.addTime(0.9);
     } else {
       // SLOPPY — landed mid-flip: keep some points, lose speed, no boost
       this.boardRot = 0;
@@ -1474,6 +1519,7 @@ export class SkateGameEngine {
       this.cb.onBank?.(400);
       this.cb.onCallout?.("CLOSE!", "close");
       this.boost = Math.min(BOOST_CAP, this.boost + 70);
+      this.addTime(1.5); // threading a gap is exactly the kind of "great" we reward
     }
   }
 
@@ -1539,6 +1585,7 @@ export class SkateGameEngine {
         this.bumpSpecial(0.05);
         this.emitCombo();
         this.sfx("bubble");
+        this.addTime(0.25); // sips of time keep you alive while you collect
         const sy = this.groundY - b.y;
         for (let i = 0; i < 5; i++) {
           this.particles.push({
@@ -1554,6 +1601,7 @@ export class SkateGameEngine {
         p.taken = true;
         this.sfx("power");
         this.flashT = 0.35;
+        this.addTime(1.5);
         if (p.kind === "magnet") {
           this.magnetT = MAGNET_T;
           this.cb.onPower?.("magnet");
@@ -1582,6 +1630,7 @@ export class SkateGameEngine {
         this.emitCombo();
         this.sfx("letter");
         this.flashT = 0.4;
+        this.addTime(1.2);
         if (this.lettersGot.every(Boolean)) {
           this.addScore(5000);
           this.cb.onBank?.(5000);
@@ -1589,6 +1638,7 @@ export class SkateGameEngine {
           this.cb.onCallout?.("S-T-R-E-M-E!", "combo");
           this.lettersGot = [false, false, false, false, false, false];
           this.cb.onLetters?.([...this.lettersGot]);
+          this.addTime(5); // spelling STREME is a big recharge
           this.enterFlow();
         }
       }
@@ -1599,7 +1649,7 @@ export class SkateGameEngine {
     }
   }
 
-  private gameOver(finished: boolean) {
+  private gameOver(finished: boolean, timedOut = false) {
     this.state = "over";
     this.cb.onGameOver?.({
       score: this.score,
@@ -1609,6 +1659,7 @@ export class SkateGameEngine {
       tricks: this.trickCount,
       distance: Math.floor(this.distance),
       finished,
+      timedOut,
     });
   }
 

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -347,6 +347,7 @@ export class SkateGameEngine {
   // run timer
   private timeLeft = START_TIME;
   private lastTimeSent = -1;
+  private sunGlide = START_TIME / TIME_CAP; // eased sun height = time remaining
 
   // visuals
   private boardRot = 0;
@@ -560,6 +561,7 @@ export class SkateGameEngine {
     this.rocketT = 0;
     this.timeLeft = START_TIME;
     this.lastTimeSent = -1;
+    this.sunGlide = START_TIME / TIME_CAP;
     this.boardRot = 0;
     this.crashT = 0;
     this.shake = 0;
@@ -1666,6 +1668,10 @@ export class SkateGameEngine {
   // ----------------------------------------------------------- visuals
 
   private advanceVisuals(dt: number, speed: number) {
+    // the sun rides the clock — ease its height toward time-remaining so it
+    // drifts down as time runs out and lifts back up when you bank a recharge
+    const sunTarget = Math.max(0, Math.min(1, this.timeLeft / TIME_CAP));
+    this.sunGlide += (sunTarget - this.sunGlide) * Math.min(1, dt * 2.2);
     const feetY = this.groundY - this.py;
     this.trail.unshift({ x: this.skaterX, y: feetY });
     if (this.trail.length > 16) this.trail.pop();
@@ -1790,8 +1796,10 @@ export class SkateGameEngine {
     ctx.globalAlpha = 1;
 
     const sunX = W * 0.62;
-    const sunY = this.groundY - H * 0.2;
     const sunR = Math.min(W, H) * 0.16;
+    // sun-as-clock: high (near noon) when time is full, sinking below the
+    // horizon as it runs out. Smoothed via sunGlide so it glides, not jumps.
+    const sunY = this.groundY + sunR - this.sunGlide * (H * 0.42 + sunR);
     const sg = ctx.createLinearGradient(0, sunY - sunR, 0, sunY + sunR);
     sg.addColorStop(0, this.sunCol(0));
     sg.addColorStop(0.45, this.sunCol(1));

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -2,9 +2,11 @@
 // arcade juice borrowed from the greats. The warplet bombs a neon street; TAP
 // to jump (hold for bigger air), HOLD IN THE AIR to backflip, then RELEASE to
 // stomp the landing upright — a clean landing pays out the combo AND kicks a
-// speed boost (the rush). Grind rails, grab $STREME, snag a Magnet or Rocket,
-// nail near-misses over the gaps, and just don't fall in. Endless, ramping
-// speed, chase a high score. Everything draws to one <canvas>; React owns HUD.
+// speed boost (the rush). Grind rails (the longer you hold the more it pays),
+// grab $STREME, snag a Magnet or Rocket, nail near-misses over the gaps, ride
+// the Sonic loop. TRUE ENDLESS, ONE LIFE — one bad gap and you're done — with a
+// research-driven difficulty curve that ramps relentlessly. Cycling neon zones,
+// chase a high score. Everything draws to one <canvas>; React owns the HUD.
 
 export type SwipeDir = "up" | "down" | "left" | "right";
 export type SfxType =
@@ -43,16 +45,17 @@ export interface SkateResult {
   bubbles: number;
   tricks: number;
   distance: number;
-  finished: boolean; // crossed the finish line vs wiped out
+  finished: boolean; // always false — endless run, you go till you wipe out
 }
 
 export interface SkateCallbacks {
   onStart?: () => void;
   onScore?: (total: number) => void;
   onDistance?: (metres: number) => void;
-  onProgress?: (fraction: number) => void; // 0..1 to the finish line
+  onProgress?: (fraction: number) => void; // 0..1 through the current zone (loops)
   onZone?: (name: string, index: number, accent: string) => void;
   onLives?: (lives: number) => void;
+  onGrindTick?: (level: number) => void; // rising grind audio (seconds on the rail)
   onCombo?: (info: ComboInfo | null) => void;
   onBank?: (amount: number) => void;
   onBail?: (lostCombo: number) => void;
@@ -84,6 +87,7 @@ interface Ramp {
 interface Loop {
   x: number; // entry x (bottom of the loop)
   r: number;
+  done?: boolean; // already ridden — don't re-trigger (we exit at its centre)
 }
 type PowerKind = "magnet" | "rocket";
 interface Collectible {
@@ -124,13 +128,18 @@ const GHOST_DT = 0.15; // seconds between recorded ghost samples
 const GHOST_COLORS = ["#fb7185", "#a78bfa", "#34d399", "#fbbf24", "#38bdf8"];
 
 const BASE_SPEED = 300;
-const MAX_SPEED = 640;
+const MAX_SPEED = 680;
 const GRAVITY = 2150;
 const JUMP_V = 820;
 const JUMP_HOLD_G = 1150; // lighter gravity while holding + rising → bigger air
 const RAIL_POP = 720;
 const RAIL_END_POP = 360;
 const METRES = 9;
+
+// grind (the longer you hold, the faster the score climbs — OlliOlli/THPS)
+const GRIND_BASE = 16; // base points per 50px of rail at multiplier 1
+const GRIND_RAMP = 1.5; // multiplier growth per second on the rail
+const COYOTE = 0.1; // grace window to still jump after rolling off an edge (Celeste)
 
 const SPIN_MAX = 13; // rad/s when flipping
 const SPIN_ACCEL = 46;
@@ -157,10 +166,11 @@ const FLOW_COLORS = [C_GOLD, C_PINK, C_CYAN, "#a855f7", C_TEAL];
 const STREME_LETTERS = ["S", "T", "R", "E", "M", "E"];
 const FLIP_NAMES = ["KICKFLIP", "360 FLIP", "BACKFLIP", "VARIAL", "HARDFLIP"];
 
-// One finite level, split into themed zones. Each zone has its own sky/sun
-// palette (visual variety) and a set-piece weight mix (gameplay variety).
-const LEVEL_LEN = 34000; // world px to the finish line (~3800m, ~70s)
-const START_LIVES = 3;
+// Endless — themed zones cycle forever (~ZONE_LEN px each), each with its own
+// sky/sun palette (visual variety) and set-piece weight mix (gameplay variety).
+// Later cycles are harder because difficulty rides the run clock, not position.
+const ZONE_LEN = 7200; // world px per zone before it transitions to the next
+const START_LIVES = 1; // one life — endless, you go till you wipe out
 
 type RGB = [number, number, number];
 interface ZonePalette {
@@ -181,7 +191,7 @@ const ZONES: Zone[] = [
       sky: [[12, 6, 38], [36, 17, 96], [109, 31, 158], [122, 42, 134]],
       sun: [[253, 230, 138], [251, 146, 60], [236, 72, 153], [168, 85, 247]],
     },
-    mix: { flat: 1.4, kickerAir: 1.4, rail: 1.4, gap: 0.6, doubleKicker: 0.5 },
+    mix: { flat: 1.4, kickerAir: 1.4, rail: 1.4, rhythm: 1.1, gap: 0.6, doubleKicker: 0.5 },
   },
   {
     name: "GRIND DISTRICT",
@@ -190,7 +200,7 @@ const ZONES: Zone[] = [
       sky: [[5, 16, 28], [8, 36, 52], [14, 92, 110], [20, 74, 92]],
       sun: [[165, 243, 252], [45, 212, 191], [56, 189, 248], [99, 102, 241]],
     },
-    mix: { rail: 2.0, railGap: 1.4, kickerRail: 1.4, kickerAir: 0.8, gap: 0.7, flat: 0.8 },
+    mix: { rail: 2.0, stairs: 1.6, railGap: 1.4, kickerRail: 1.4, kickerAir: 0.8, gap: 0.7, flat: 0.8 },
   },
   {
     name: "GAP CITY",
@@ -208,16 +218,16 @@ const ZONES: Zone[] = [
       sky: [[12, 6, 38], [42, 13, 84], [122, 31, 174], [192, 38, 160]],
       sun: [[244, 114, 182], [219, 39, 119], [168, 85, 247], [88, 28, 135]],
     },
-    mix: { quarter: 1.6, kickerAir: 1.6, kickerRail: 1.4, doubleKicker: 1.2, kickerGap: 1.0, loop: 1.0, flat: 0.6 },
+    mix: { quarter: 1.6, kickerAir: 1.6, kickerRail: 1.4, stairs: 1.2, doubleKicker: 1.2, kickerGap: 1.0, loop: 1.0, flat: 0.6 },
   },
   {
-    name: "THE FINISH RUSH",
+    name: "OVERDRIVE",
     accent: "#fbbf24",
     pal: {
       sky: [[22, 8, 38], [90, 18, 64], [236, 72, 153], [251, 191, 36]],
       sun: [[253, 230, 138], [244, 114, 182], [239, 68, 68], [124, 28, 92]],
     },
-    mix: { quarter: 1.4, kickerGap: 1.4, kickerAir: 1.3, doubleKicker: 1.2, rail: 1.0, gap: 1.2, kickerRail: 1.2, loop: 1.1 },
+    mix: { quarter: 1.4, kickerGap: 1.4, kickerAir: 1.3, rhythm: 1.2, doubleKicker: 1.2, rail: 1.0, gap: 1.2, kickerRail: 1.2, loop: 1.1 },
   },
 ];
 
@@ -288,14 +298,15 @@ export class SkateGameEngine {
   private currentRail: Rail | null = null;
   private jumpedGap: Gap | null = null;
   private rampUnder: Ramp | null = null; // ramp we're riding (for lip-launch)
-  // pacing state (designed level flow)
+  private coyoteT = 0; // grace window to still jump after rolling off an edge
+  // pacing state (designed level flow — warm-up → challenge clusters → rest)
   private chunkCount = 0;
   private lastChunk = "";
   private restoreBreather = false;
-  private finishX = LEVEL_LEN;
+  private challengeRun = 0; // consecutive HARD chunks (force a breather after a few)
+  private chunksSinceReward = 0; // periodic reward corridor cadence
   private lastProgressSent = -1;
   private lastZone = -1;
-  private finishLaid = false;
   private lives = START_LIVES;
 
   // air / trick
@@ -308,6 +319,9 @@ export class SkateGameEngine {
   private comboBase = 0;
   private lastTrickName = "";
   private grindAccrual = 0;
+  private grindTime = 0; // seconds on the current rail (drives the escalating payout)
+  private grindTier = 0; // 0..3 → GRINDING / ON FIRE / LEGENDARY callout thresholds
+  private grindTickT = 0; // countdown to the next rising grind audio tick
   private bankedPoints = 0;
   private bestCombo = 0;
   private trickCount = 0;
@@ -398,6 +412,7 @@ export class SkateGameEngine {
       // a deliberate jump off a ramp lip launches even bigger (but on-screen)
       const rampBoost = this.rampUnder ? this.rampUnder.launch * 0.4 : 0;
       this.rampUnder = null;
+      this.coyoteT = 0;
       this.vy = Math.min(JUMP_V + rampBoost, 960);
       this.py = Math.max(this.py, 0.1);
       this.state = "airborne";
@@ -409,10 +424,32 @@ export class SkateGameEngine {
       this.trickCount++;
       this.emitCombo();
       this.sfx("jump");
+    } else if (this.state === "airborne" && this.coyoteT > 0) {
+      // coyote time — a late tap after rolling off an edge still jumps, so a
+      // one-life death never feels like the button was ignored (Celeste)
+      this.coyoteT = 0;
+      this.vy = JUMP_V;
+      this.comboTricks.push("AIR");
+      this.comboBase += 40;
+      this.trickCount++;
+      this.emitCombo();
+      this.sfx("jump");
     } else if (this.state === "grinding") {
+      const rail = this.currentRail;
+      // perfect-exit: pop off in the last slice of the rail to bank a fat
+      // bonus on the whole grind (OlliOlli's perfect dismount)
+      if (rail && rail.x1 - this.px < 70 && this.grindTime > 0.25) {
+        this.comboBase *= 1.8;
+        this.cb.onCallout?.("PERFECT EXIT!", "perfect");
+        this.sfx("perfect");
+        this.shake = 0.4;
+        this.flashT = 0.2;
+        this.emitCombo();
+      }
       this.vy = RAIL_POP;
       this.state = "airborne";
       this.currentRail = null;
+      this.grindTier = 0;
       this.spinV = 0;
       this.rotAccum = 0;
       this.sfx("jump");
@@ -465,11 +502,12 @@ export class SkateGameEngine {
     this.chunkCount = 0;
     this.lastChunk = "";
     this.restoreBreather = false;
-    this.finishX = LEVEL_LEN;
+    this.challengeRun = 0;
+    this.chunksSinceReward = 0;
     this.lastProgressSent = -1;
     this.lastZone = -1;
-    this.finishLaid = false;
     this.lives = START_LIVES;
+    this.coyoteT = 0;
     this.px = 0;
     this.py = 0;
     this.vy = 0;
@@ -493,6 +531,9 @@ export class SkateGameEngine {
     this.comboBase = 0;
     this.lastTrickName = "";
     this.grindAccrual = 0;
+    this.grindTime = 0;
+    this.grindTier = 0;
+    this.grindTickT = 0;
     this.bankedPoints = 0;
     this.bestCombo = 0;
     this.trickCount = 0;
@@ -666,24 +707,29 @@ export class SkateGameEngine {
   private waveSeed = 20240611;
 
   private difficulty(): number {
-    // ramps with progress through the finite level (gentle at the start)
-    return Math.min(this.px / this.finishX, 1);
+    // endless: difficulty rides the run clock, not position. Gentle for the
+    // first ~80s, then holds near max while speed + pacing keep ramping.
+    return Math.min(this.runTime / 80, 1);
   }
 
   private zoneIndexAt(worldX: number): number {
-    const t = worldX / this.finishX;
-    return Math.max(0, Math.min(ZONES.length - 1, Math.floor(t * ZONES.length)));
+    // zones cycle forever; later laps are harder because difficulty() climbs
+    return Math.floor(Math.max(0, worldX) / ZONE_LEN) % ZONES.length;
+  }
+
+  /** Extra runway before a hazard, scaled by speed so fast = more warning. */
+  private lead(base: number): number {
+    return base + this.effSpeed() * 0.16;
   }
 
   private primeCourse() {
     this.waveSeed = 20240611;
     this.cursorX = 760;
-    this.finishLaid = false;
     while (this.cursorX < this.px + this.W * 2.5) this.addChunk();
   }
 
   private generateAhead() {
-    while (this.cursorX < this.px + this.W * 2.5 && !this.finishLaid) {
+    while (this.cursorX < this.px + this.W * 2.5) {
       this.addChunk();
     }
     const cull = this.px - this.W;
@@ -762,7 +808,7 @@ export class SkateGameEngine {
     const x = this.cursorX;
     const d = this.difficulty();
     const w = 90 + d * 80 + this.rand(50);
-    const gx = x + 140 + this.rand(60);
+    const gx = x + this.lead(120) + this.rand(60);
     this.gaps.push({ x0: gx, x1: gx + w });
     this.bubbleArc(gx + w / 2, 120, 70, 5, 34);
     this.maybeLetter(gx + w / 2, 170);
@@ -774,7 +820,7 @@ export class SkateGameEngine {
     // WIDE gap — always fronted by a ramp so it's clearable (solvability rule)
     const x = this.cursorX;
     const d = this.difficulty();
-    const r = this.addRamp(x + 120 + this.rand(40), "med");
+    const r = this.addRamp(x + this.lead(110) + this.rand(40), "med");
     const w = 170 + d * 200 + this.rand(70);
     const gx = r.xLip + 6;
     this.gaps.push({ x0: gx, x1: gx + w });
@@ -800,7 +846,7 @@ export class SkateGameEngine {
     const x = this.cursorX;
     const len = 240 + this.rand(140);
     const h = 64 + this.rand(20);
-    const rx = x + 130 + this.rand(50);
+    const rx = x + this.lead(110) + this.rand(50);
     this.rails.push({ x0: rx, x1: rx + len, height: h });
     const gx = rx + len * 0.32;
     this.gaps.push({ x0: gx, x1: gx + Math.min(len * 0.36, 140) });
@@ -857,6 +903,63 @@ export class SkateGameEngine {
     this.cursorX = lx + 2 * LOOP_R + 300;
   }
 
+  private spRhythm() {
+    // a cadence of evenly spaced little kickers — muscle-memory bouncing, the
+    // "rhythm game" beat OlliOlli leans on. No gaps, just flow + coins.
+    const x = this.cursorX;
+    let rx = x + 110;
+    const n = 3 + Math.floor(this.rand(1.6));
+    for (let i = 0; i < n; i++) {
+      const r = this.addRamp(rx, "small");
+      this.bubbleArc(r.xLip + 48, r.height + 34, 64, 3, 30);
+      rx = r.xLip + 150;
+    }
+    this.maybeLetter(x + 200, 150);
+    this.cursorX = rx + 130;
+  }
+
+  private spStairs() {
+    // a descending grind staircase — chain three rails stepping down, each
+    // landing on solid ground (a satisfying grind line, no pit risk)
+    const x = this.cursorX;
+    let rx = x + 130;
+    let h = 124 + this.rand(20);
+    for (let i = 0; i < 3; i++) {
+      const len = 116 + this.rand(40);
+      this.rails.push({ x0: rx, x1: rx + len, height: h });
+      this.coinLine(rx + 16, h + 18, 3, len / 3);
+      rx += len + 42;
+      h = Math.max(40, h - 34);
+    }
+    this.maybeLetter(x + 220, 170);
+    this.cursorX = rx + 150;
+  }
+
+  private spRest() {
+    // a forced breather after a challenge cluster — long, safe, coins to grab
+    const x = this.cursorX;
+    const len = 320 + this.rand(120);
+    this.coinLine(x + 50, 44, 8, 52);
+    this.maybeLetter(x + len / 2, 110);
+    this.cursorX = x + len;
+  }
+
+  private spReward() {
+    // a no-risk reward corridor before the difficulty climbs (positive surprise)
+    const x = this.cursorX;
+    const len = 300;
+    this.bubbleArc(x + len / 2, 80, 92, 7, 38);
+    this.powers.push({
+      x: x + len / 2,
+      y: 120,
+      kind: this.powerIdx++ % 2 === 0 ? "magnet" : "rocket",
+      taken: false,
+    });
+    this.chunksSincePower = 0;
+    this.maybeLetter(x + len * 0.82, 150);
+    this.cursorX = x + len + 120;
+  }
+
   private readonly HARD = new Set(["kickerGap", "railGap", "kickerRail", "quarter"]);
 
   private buildChunk(name: string, d: number) {
@@ -871,39 +974,76 @@ export class SkateGameEngine {
       case "railGap": this.spRailGap(); break;
       case "quarter": this.spQuarter(); break;
       case "loop": this.spLoop(); break;
+      case "rhythm": this.spRhythm(); break;
+      case "stairs": this.spStairs(); break;
       default: this.spFlat();
     }
   }
 
+  /** Which set pieces are unlocked yet — gradual mechanic introduction. */
+  private unlocked(name: string, t: number): boolean {
+    switch (name) {
+      case "gap": return t > 16;
+      case "doubleKicker": return t > 20;
+      case "rhythm": return t > 18;
+      case "stairs": return t > 26;
+      case "railGap": return t > 28;
+      case "kickerRail": return t > 30;
+      case "kickerGap": return t > 38;
+      case "quarter": return t > 46;
+      case "loop": return t > 58;
+      default: return true; // flat, kickerAir, rail — always available
+    }
+  }
+
+  /** Bias the weighted pick by difficulty: hard/dense late, flat early. */
+  private chunkBias(name: string, d: number): number {
+    if (this.HARD.has(name)) return 0.45 + d * 1.25; // rare early → common late
+    if (name === "flat") return Math.max(0.25, 1.3 - d * 0.9); // common early
+    return 1;
+  }
+
   private addChunk() {
-    if (this.finishLaid) return;
     this.chunkCount++;
     const d = this.difficulty();
+    const t = this.runTime;
 
-    // reached the end → lay a calm run-in and the finish gate
-    if (this.cursorX >= this.finishX - 700) {
-      this.coinLine(this.cursorX + 40, 44, 8, 56);
-      this.cursorX = this.finishX + 200;
-      this.finishLaid = true;
-      this.lastChunk = "finish";
+    // --- opening: orient to speed + teach the mechanics on safe ground ---
+    if (this.chunkCount <= 2) { this.spFlat(); this.lastChunk = "flat"; return; }
+    if (this.chunkCount <= 4) { this.spKickerAir("small"); this.lastChunk = "kickerAir"; return; }
+    if (this.chunkCount === 5) { this.spRail(); this.lastChunk = "rail"; return; }
+
+    // --- forced REST after a challenge cluster (tension → release) ---
+    if (this.restoreBreather) {
+      this.restoreBreather = false;
+      this.challengeRun = 0;
+      this.spRest();
+      this.lastChunk = "flat";
       return;
     }
 
-    // opening grace: orient to speed + controls on flat ground (no hazards)
-    if (this.chunkCount <= 3) { this.spFlat(); this.lastChunk = "flat"; return; }
-    // teach the ramp in isolation — air with no hazard after it
-    if (this.chunkCount <= 5) { this.spKickerAir("small"); this.lastChunk = "kickerAir"; return; }
-    // mandatory breather after a hard set piece (tension → release)
-    if (this.restoreBreather) { this.restoreBreather = false; this.spFlat(); this.lastChunk = "flat"; return; }
+    // --- periodic REWARD corridor before the difficulty climbs ---
+    if (this.chunksSinceReward >= 6 && this.rand(1) < 0.6) {
+      this.chunksSinceReward = 0;
+      this.spReward();
+      this.lastChunk = "reward";
+      return;
+    }
 
-    // pick from THIS ZONE's weighted mix — no immediate repeats
+    // --- pick from this zone's mix: unlocked, no repeat, no two HARD in a row,
+    //     weighted toward harder pieces as difficulty climbs ---
     const zone = ZONES[this.zoneIndexAt(this.cursorX)];
+    const lastHard = this.HARD.has(this.lastChunk);
     const choices: [string, number][] = [];
     for (const name in zone.mix) {
       const w = zone.mix[name];
-      if (w > 0 && name !== this.lastChunk) choices.push([name, w]);
+      if (w <= 0) continue;
+      if (name === this.lastChunk) continue;
+      if (!this.unlocked(name, t)) continue;
+      if (lastHard && this.HARD.has(name)) continue;
+      choices.push([name, w * this.chunkBias(name, d)]);
     }
-    if (choices.length === 0) choices.push(["flat", 1]);
+    if (choices.length === 0) { this.spFlat(); this.lastChunk = "flat"; return; }
 
     const total = choices.reduce((s, [, w]) => s + w, 0);
     let r = this.rand(total);
@@ -914,7 +1054,14 @@ export class SkateGameEngine {
     }
 
     this.buildChunk(pick, d);
-    if (this.HARD.has(pick)) this.restoreBreather = true;
+    this.chunksSinceReward++;
+    if (this.HARD.has(pick)) {
+      this.challengeRun++;
+      // breather after 2 hard chunks early, 3 once the player is warmed up
+      if (this.challengeRun >= (d > 0.55 ? 3 : 2)) this.restoreBreather = true;
+    } else {
+      this.challengeRun = 0;
+    }
     this.lastChunk = pick;
   }
 
@@ -1022,7 +1169,10 @@ export class SkateGameEngine {
         const l = this.loopActive;
         this.loopActive = null;
         this.state = "running";
-        if (l) this.px = l.x + 2 * l.r + 30;
+        // exit at the ring's centre (where the skater already is at the bottom
+        // of the loop) so running resumes seamlessly — no forward snap. phi at
+        // loopT=1 is 2π ≡ 0, so boardRot=0 is continuous too.
+        if (l) { l.done = true; this.px = l.x + l.r; }
         this.py = 0;
         this.vy = 0;
         this.boardRot = 0;
@@ -1037,27 +1187,16 @@ export class SkateGameEngine {
     }
 
     if (this.state === "crash") {
+      // plunge straight down into the pit (world frozen so the hole stays put
+      // under the falling rider), tumbling, until off-screen → game over
       this.crashT += dt;
-      this.boardRot += 8 * dt;
-      this.py += this.vy * dt;
+      this.boardRot += 9 * dt;
       this.vy -= GRAVITY * dt;
-      this.advanceVisuals(dt, this.speed * 0.4);
+      this.py += this.vy * dt;
+      this.advanceVisuals(dt, 0);
       if (this.shake > 0) this.shake = Math.max(0, this.shake - dt * 2.5);
-      if (this.crashT > 0.85) {
-        if (this.lives <= 0) {
-          this.gameOver(false);
-        } else {
-          // get back up past the pit and keep skating
-          const g = this.gaps.find((gp) => this.px > gp.x0 - 30 && this.px < gp.x1 + 30);
-          if (g) this.px = g.x1 + 40;
-          this.py = 0;
-          this.vy = 0;
-          this.boardRot = 0;
-          this.spinV = 0;
-          this.rampUnder = null;
-          this.speed = BASE_SPEED;
-          this.state = "running";
-        }
+      if (this.py < -this.groundY - 80 || this.crashT > 1.3) {
+        this.gameOver(false);
       }
       return;
     }
@@ -1075,9 +1214,11 @@ export class SkateGameEngine {
     }
     this.refreshScore();
 
-    // ---- finite-level progress, zone changes, and the finish line
-    const frac = Math.min(this.px / this.finishX, 1);
-    if (frac - this.lastProgressSent >= 0.004) {
+    // ---- endless progress: a looping bar that fills across each zone, plus a
+    //      name callout when a new biome begins
+    const zp = this.px / ZONE_LEN;
+    const frac = zp - Math.floor(zp); // 0..1 through the current zone
+    if (Math.abs(frac - this.lastProgressSent) >= 0.01 || frac < this.lastProgressSent) {
       this.lastProgressSent = frac;
       this.cb.onProgress?.(frac);
     }
@@ -1091,19 +1232,18 @@ export class SkateGameEngine {
         this.sfx("milestone");
       }
     }
-    if (this.px >= this.finishX) {
-      this.finish();
-      return;
-    }
 
-    // enter a Sonic loop when we roll onto one (grounded, not in a rocket)
+    // enter a Sonic loop when we reach its centre (grounded, not in a rocket).
+    // Triggering at the centre — where we also exit — keeps entry/exit smooth.
     if (this.state === "running" && this.py < 12 && this.rocketT <= 0) {
-      const loop = this.loops.find((l) => this.px >= l.x && this.px < l.x + 50);
+      const loop = this.loops.find(
+        (l) => !l.done && this.px >= l.x + l.r - 30 && this.px <= l.x + l.r + 30
+      );
       if (loop) {
         this.state = "loop";
         this.loopActive = loop;
         this.loopT = 0;
-        this.px = loop.x;
+        this.px = loop.x + loop.r;
         this.rampUnder = null;
         this.sfx("grind");
         this.advanceVisuals(dt, 0);
@@ -1130,6 +1270,7 @@ export class SkateGameEngine {
           this.rampUnder = null;
           this.state = "airborne";
           this.vy = -40;
+          this.coyoteT = COYOTE; // brief grace to still pop a jump after the edge
         } else if (this.rampUnder && this.px < this.rampUnder.xLip + 90) {
           // crossed the lip (even if a fast frame skipped the exact window) —
           // launch up + forward instead of snapping straight down to the street
@@ -1143,6 +1284,7 @@ export class SkateGameEngine {
         }
       }
     } else if (this.state === "airborne") {
+      if (this.coyoteT > 0) this.coyoteT = Math.max(0, this.coyoteT - dt);
       const g = this.holding && this.vy > 0 ? JUMP_HOLD_G : GRAVITY;
       this.vy -= g * dt;
       this.py += this.vy * dt;
@@ -1178,6 +1320,10 @@ export class SkateGameEngine {
           this.spinV = 0;
           this.state = "grinding";
           this.grindAccrual = 0;
+          this.grindTime = 0;
+          this.grindTier = 0;
+          this.grindTickT = 0;
+          this.coyoteT = 0;
           this.boardRot = 0;
           this.addTrick("50-50 GRIND", 120);
           this.sfx("grind");
@@ -1195,19 +1341,44 @@ export class SkateGameEngine {
     } else if (this.state === "grinding") {
       const rail = this.currentRail;
       if (!rail || this.px > rail.x1) {
+        // rode off the end without popping — small hop back to skating
         this.currentRail = null;
         this.state = "airborne";
         this.vy = RAIL_END_POP;
+        this.grindTier = 0;
       } else {
         this.py = rail.height;
+        this.grindTime += dt;
+        // the longer you hold, the faster the score climbs (THPS multiplier)
+        const gmult = 1 + this.grindTime * GRIND_RAMP;
         this.grindAccrual += eff * dt;
-        while (this.grindAccrual >= 60) {
-          this.grindAccrual -= 60;
-          this.comboBase += 24;
+        while (this.grindAccrual >= 50) {
+          this.grindAccrual -= 50;
+          this.comboBase += Math.round(GRIND_BASE * gmult);
           this.bumpSpecial(0.012);
           this.emitCombo();
         }
-        if (this.rand(1) < 0.6) this.spark(this.skaterX, this.groundY - this.py, 1);
+        // sparks get denser as the grind builds; audio ticks rise in pitch
+        const sparkN = this.grindTime > 2.5 ? 2 : 1;
+        if (this.rand(1) < Math.min(1, 0.45 + this.grindTime * 0.35)) {
+          this.spark(this.skaterX, this.groundY - this.py, sparkN);
+        }
+        this.grindTickT -= dt;
+        if (this.grindTickT <= 0) {
+          this.grindTickT = Math.max(0.07, 0.2 - this.grindTime * 0.03);
+          this.cb.onGrindTick?.(this.grindTime);
+        }
+        // threshold callouts ratchet the tension
+        const tier =
+          this.grindTime >= 4 ? 3 : this.grindTime >= 2.5 ? 2 : this.grindTime >= 1 ? 1 : 0;
+        if (tier > this.grindTier) {
+          this.grindTier = tier;
+          this.cb.onCallout?.(
+            tier === 3 ? "LEGENDARY!" : tier === 2 ? "ON FIRE!" : "GRINDING!",
+            "combo"
+          );
+          this.shake = Math.max(this.shake, 0.15 + tier * 0.1);
+        }
       }
     }
 
@@ -1323,22 +1494,25 @@ export class SkateGameEngine {
   }
 
   private crash() {
+    // missed the gap — plunge into the pit. vy is set negative so the rider
+    // drops *down* (not the old upward pop); the crash state finishes the fall.
     const lost = this.loseCombo() ?? 0;
     this.lives = Math.max(0, this.lives - 1);
     this.cb.onLives?.(this.lives);
     this.state = "crash";
     this.crashT = 0;
-    this.vy = 240;
-    this.shake = 1;
+    this.vy = -80;
+    this.shake = 0.9;
     this.sfx("crash");
     this.cb.onBail?.(lost);
+    // debris kicks up from the lip even as the rider drops away
     const sy = this.groundY - this.py;
     for (let i = 0; i < 18; i++) {
       this.particles.push({
         x: this.skaterX,
         y: sy,
         vx: this.rand(260) - 130,
-        vy: -this.rand(260),
+        vy: -this.rand(240),
         life: 0.7,
         maxLife: 0.7,
         color: i % 2 ? C_PINK : "#ffffff",
@@ -1438,17 +1612,6 @@ export class SkateGameEngine {
     });
   }
 
-  private finish() {
-    // crossed the finish line — bank the run, completion bonus, celebrate
-    this.bankCombo(1);
-    this.cb.onProgress?.(1);
-    this.addScore(10000);
-    this.cb.onBank?.(10000);
-    this.cb.onCallout?.("LEVEL COMPLETE!", "combo");
-    this.flashT = 0.6;
-    this.gameOver(true);
-  }
-
   // ----------------------------------------------------------- visuals
 
   private advanceVisuals(dt: number, speed: number) {
@@ -1497,7 +1660,6 @@ export class SkateGameEngine {
     this.drawRamps(ctx);
     this.drawLoops(ctx);
     this.drawRails(ctx);
-    this.drawFinish(ctx);
     this.drawCollectibles(ctx);
     this.drawGhosts(ctx);
     this.drawTrail(ctx);
@@ -1542,16 +1704,18 @@ export class SkateGameEngine {
     )},${Math.round(a[2] + (b[2] - a[2]) * t)})`;
   }
 
-  /** Interpolated zone palette slot (0..3) by progress through the level. */
+  /** Interpolated zone palette slot (0..3), cycling smoothly between biomes. */
   private skyCol(slot: number): string {
-    const t = Math.min(this.px / this.finishX, 1) * (ZONES.length - 1);
-    const i = Math.min(ZONES.length - 2, Math.max(0, Math.floor(t)));
-    return this.lerpRGB(ZONES[i].pal.sky[slot], ZONES[i + 1].pal.sky[slot], t - i);
+    const p = Math.max(0, this.px) / ZONE_LEN;
+    const i = Math.floor(p) % ZONES.length;
+    const j = (i + 1) % ZONES.length;
+    return this.lerpRGB(ZONES[i].pal.sky[slot], ZONES[j].pal.sky[slot], p - Math.floor(p));
   }
   private sunCol(slot: number): string {
-    const t = Math.min(this.px / this.finishX, 1) * (ZONES.length - 1);
-    const i = Math.min(ZONES.length - 2, Math.max(0, Math.floor(t)));
-    return this.lerpRGB(ZONES[i].pal.sun[slot], ZONES[i + 1].pal.sun[slot], t - i);
+    const p = Math.max(0, this.px) / ZONE_LEN;
+    const i = Math.floor(p) % ZONES.length;
+    const j = (i + 1) % ZONES.length;
+    return this.lerpRGB(ZONES[i].pal.sun[slot], ZONES[j].pal.sun[slot], p - Math.floor(p));
   }
 
   private drawSky(ctx: CanvasRenderingContext2D, W: number, H: number) {
@@ -1712,38 +1876,6 @@ export class SkateGameEngine {
       ctx.fillRect(xL - 5, this.groundY - r.height - 3, 7, 5);
       ctx.shadowBlur = 0;
     }
-  }
-
-  private drawFinish(ctx: CanvasRenderingContext2D) {
-    const fx = this.sx(this.finishX);
-    if (fx < -90 || fx > this.W + 90) return;
-    const base = this.groundY;
-    const top = base - 170;
-    const cw = 9;
-    // checkered banner
-    for (let row = 0; row < 3; row++) {
-      for (let c = 0; c < 6; c++) {
-        ctx.fillStyle = (row + c) % 2 ? "#ffffff" : "#0c0626";
-        ctx.fillRect(fx + c * cw, top + row * cw, cw, cw);
-      }
-    }
-    // glowing posts
-    ctx.strokeStyle = C_GOLD;
-    ctx.shadowColor = C_GOLD;
-    ctx.shadowBlur = 12;
-    ctx.lineWidth = 4;
-    ctx.beginPath();
-    ctx.moveTo(fx, top);
-    ctx.lineTo(fx, base);
-    ctx.moveTo(fx + 54, top);
-    ctx.lineTo(fx + 54, base);
-    ctx.stroke();
-    ctx.shadowBlur = 0;
-    ctx.fillStyle = C_GOLD;
-    ctx.font = "bold 13px ui-monospace, monospace";
-    ctx.textAlign = "center";
-    ctx.fillText("FINISH", fx + 27, top - 10);
-    ctx.textAlign = "left";
   }
 
   private drawLoops(ctx: CanvasRenderingContext2D) {

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -1,0 +1,2016 @@
+// Streme Skate — a 2D, pixel-art, GBA-flavoured one-button endless skater with
+// arcade juice borrowed from the greats. The warplet bombs a neon street; TAP
+// to jump (hold for bigger air), HOLD IN THE AIR to backflip, then RELEASE to
+// stomp the landing upright — a clean landing pays out the combo AND kicks a
+// speed boost (the rush). Grind rails, grab $STREME, snag a Magnet or Rocket,
+// nail near-misses over the gaps, and just don't fall in. Endless, ramping
+// speed, chase a high score. Everything draws to one <canvas>; React owns HUD.
+
+export type SwipeDir = "up" | "down" | "left" | "right";
+export type SfxType =
+  | "jump"
+  | "trick"
+  | "land"
+  | "perfect"
+  | "grind"
+  | "crash"
+  | "letter"
+  | "bubble"
+  | "power"
+  | "flow"
+  | "milestone";
+
+export type CalloutKind =
+  | "perfect"
+  | "sick"
+  | "sloppy"
+  | "close"
+  | "combo"
+  | "power"
+  | "milestone";
+
+export interface ComboInfo {
+  tricks: string[];
+  base: number;
+  multiplier: number;
+  live: number;
+}
+
+export interface SkateResult {
+  score: number;
+  bestCombo: number;
+  letters: number;
+  bubbles: number;
+  tricks: number;
+  distance: number;
+  finished: boolean; // crossed the finish line vs wiped out
+}
+
+export interface SkateCallbacks {
+  onStart?: () => void;
+  onScore?: (total: number) => void;
+  onDistance?: (metres: number) => void;
+  onProgress?: (fraction: number) => void; // 0..1 to the finish line
+  onZone?: (name: string, index: number, accent: string) => void;
+  onLives?: (lives: number) => void;
+  onCombo?: (info: ComboInfo | null) => void;
+  onBank?: (amount: number) => void;
+  onBail?: (lostCombo: number) => void;
+  onCallout?: (text: string, kind: CalloutKind) => void;
+  onLetters?: (collected: boolean[]) => void; // one bool per STREME slot
+  onAllLetters?: () => void;
+  onFlow?: (active: boolean) => void;
+  onSpecial?: (value: number) => void;
+  onPower?: (kind: "magnet" | "rocket" | null) => void;
+  onSfx?: (type: SfxType) => void;
+  onGameOver?: (result: SkateResult) => void;
+}
+
+interface Gap {
+  x0: number;
+  x1: number;
+}
+interface Rail {
+  x0: number;
+  x1: number;
+  height: number;
+}
+interface Ramp {
+  x0: number;
+  xLip: number;
+  height: number;
+  launch: number;
+}
+interface Loop {
+  x: number; // entry x (bottom of the loop)
+  r: number;
+}
+type PowerKind = "magnet" | "rocket";
+interface Collectible {
+  x: number;
+  y: number;
+  taken: boolean;
+}
+interface Letter extends Collectible {
+  ch: string;
+  slot: number; // which STREME slot (0..5) this letter fills
+}
+interface Power extends Collectible {
+  kind: PowerKind;
+}
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  color: string;
+  size: number;
+}
+
+/** A recorded run: flat [px,py] pairs sampled every GHOST_DT seconds. */
+export interface GhostInput {
+  samples: number[];
+  color: string;
+  name?: string;
+}
+interface Ghost {
+  samples: number[];
+  color: string;
+  name?: string;
+}
+const GHOST_DT = 0.15; // seconds between recorded ghost samples
+const GHOST_COLORS = ["#fb7185", "#a78bfa", "#34d399", "#fbbf24", "#38bdf8"];
+
+const BASE_SPEED = 300;
+const MAX_SPEED = 640;
+const GRAVITY = 2150;
+const JUMP_V = 820;
+const JUMP_HOLD_G = 1150; // lighter gravity while holding + rising → bigger air
+const RAIL_POP = 720;
+const RAIL_END_POP = 360;
+const METRES = 9;
+
+const SPIN_MAX = 13; // rad/s when flipping
+const SPIN_ACCEL = 46;
+const FLIP_BASE = 130; // points per completed rotation
+
+const BOOST_PERFECT = 230;
+const BOOST_SICK = 90;
+const BOOST_DECAY = 150;
+const BOOST_CAP = 300;
+
+const MAGNET_T = 6;
+const MAGNET_R = 175;
+const ROCKET_T = 3.2;
+const ROCKET_SPEED = 300;
+
+const C_INDIGO = "#6366f1";
+const C_PINK = "#ec4899";
+const C_TEAL = "#2dd4bf";
+const C_CYAN = "#67e8f9";
+const C_GOLD = "#fde68a";
+const TRAIL_COLORS = [C_INDIGO, C_PINK, C_TEAL];
+const FLOW_COLORS = [C_GOLD, C_PINK, C_CYAN, "#a855f7", C_TEAL];
+
+const STREME_LETTERS = ["S", "T", "R", "E", "M", "E"];
+const FLIP_NAMES = ["KICKFLIP", "360 FLIP", "BACKFLIP", "VARIAL", "HARDFLIP"];
+
+// One finite level, split into themed zones. Each zone has its own sky/sun
+// palette (visual variety) and a set-piece weight mix (gameplay variety).
+const LEVEL_LEN = 34000; // world px to the finish line (~3800m, ~70s)
+const START_LIVES = 3;
+
+type RGB = [number, number, number];
+interface ZonePalette {
+  sky: [RGB, RGB, RGB, RGB]; // top → upper-mid → horizon → ground line
+  sun: [RGB, RGB, RGB, RGB];
+}
+interface Zone {
+  name: string;
+  accent: string; // hud bar colour
+  pal: ZonePalette;
+  mix: Record<string, number>; // set-piece weights
+}
+const ZONES: Zone[] = [
+  {
+    name: "NEON DOWNTOWN",
+    accent: "#67e8f9",
+    pal: {
+      sky: [[12, 6, 38], [36, 17, 96], [109, 31, 158], [122, 42, 134]],
+      sun: [[253, 230, 138], [251, 146, 60], [236, 72, 153], [168, 85, 247]],
+    },
+    mix: { flat: 1.4, kickerAir: 1.4, rail: 1.4, gap: 0.6, doubleKicker: 0.5 },
+  },
+  {
+    name: "GRIND DISTRICT",
+    accent: "#2dd4bf",
+    pal: {
+      sky: [[5, 16, 28], [8, 36, 52], [14, 92, 110], [20, 74, 92]],
+      sun: [[165, 243, 252], [45, 212, 191], [56, 189, 248], [99, 102, 241]],
+    },
+    mix: { rail: 2.0, railGap: 1.4, kickerRail: 1.4, kickerAir: 0.8, gap: 0.7, flat: 0.8 },
+  },
+  {
+    name: "GAP CITY",
+    accent: "#fb923c",
+    pal: {
+      sky: [[26, 8, 38], [74, 18, 48], [209, 69, 58], [240, 138, 42]],
+      sun: [[254, 240, 138], [251, 146, 60], [239, 68, 68], [136, 19, 55]],
+    },
+    mix: { gap: 1.8, kickerGap: 1.8, doubleKicker: 1.2, kickerAir: 0.9, rail: 0.7, flat: 0.7 },
+  },
+  {
+    name: "VERT HEIGHTS",
+    accent: "#c084fc",
+    pal: {
+      sky: [[12, 6, 38], [42, 13, 84], [122, 31, 174], [192, 38, 160]],
+      sun: [[244, 114, 182], [219, 39, 119], [168, 85, 247], [88, 28, 135]],
+    },
+    mix: { quarter: 1.6, kickerAir: 1.6, kickerRail: 1.4, doubleKicker: 1.2, kickerGap: 1.0, loop: 1.0, flat: 0.6 },
+  },
+  {
+    name: "THE FINISH RUSH",
+    accent: "#fbbf24",
+    pal: {
+      sky: [[22, 8, 38], [90, 18, 64], [236, 72, 153], [251, 191, 36]],
+      sun: [[253, 230, 138], [244, 114, 182], [239, 68, 68], [124, 28, 92]],
+    },
+    mix: { quarter: 1.4, kickerGap: 1.4, kickerAir: 1.3, doubleKicker: 1.2, rail: 1.0, gap: 1.2, kickerRail: 1.2, loop: 1.1 },
+  },
+];
+
+interface TrickDef {
+  name: string;
+  base: number;
+}
+const AIR_TRICKS: Record<SwipeDir, TrickDef> = {
+  up: { name: "STREME GRAB", base: 140 },
+  down: { name: "SHUV-IT", base: 150 },
+  left: { name: "BIGSPIN", base: 180 },
+  right: { name: "IMPOSSIBLE", base: 190 },
+};
+
+const LOOP_DUR = 0.62; // seconds to ride a Sonic loop
+const LOOP_R = 72;
+
+type State =
+  | "idle"
+  | "running"
+  | "airborne"
+  | "grinding"
+  | "loop"
+  | "crash"
+  | "over";
+
+export class SkateGameEngine {
+  private container: HTMLElement;
+  private cb: SkateCallbacks;
+  private canvas: HTMLCanvasElement;
+  private ctx: CanvasRenderingContext2D;
+  private dpr = 1;
+  private W = 0;
+  private H = 0;
+  private groundY = 0;
+  private skaterX = 0;
+  private rafId: number | null = null;
+  private lastTime: number | null = null;
+  private disposed = false;
+
+  private state: State = "idle";
+  private holding = false;
+  private px = 0;
+  private py = 0;
+  private vy = 0;
+  private speed = BASE_SPEED;
+  private boost = 0;
+  private score = 0;
+  private distance = 0;
+  private lastScoreSent = -1;
+  private lastDistSent = -1;
+
+  // course
+  private gaps: Gap[] = [];
+  private rails: Rail[] = [];
+  private bubbles: Collectible[] = [];
+  private letters: Letter[] = [];
+  private powers: Power[] = [];
+  private ramps: Ramp[] = [];
+  private loops: Loop[] = [];
+  private loopActive: Loop | null = null;
+  private loopT = 0;
+  private cursorX = 0;
+  private nextLetterAt = 0;
+  private letterIdx = 0;
+  private chunksSincePower = 0;
+  private powerIdx = 0;
+  private currentRail: Rail | null = null;
+  private jumpedGap: Gap | null = null;
+  private rampUnder: Ramp | null = null; // ramp we're riding (for lip-launch)
+  // pacing state (designed level flow)
+  private chunkCount = 0;
+  private lastChunk = "";
+  private restoreBreather = false;
+  private finishX = LEVEL_LEN;
+  private lastProgressSent = -1;
+  private lastZone = -1;
+  private finishLaid = false;
+  private lives = START_LIVES;
+
+  // air / trick
+  private spinV = 0;
+  private rotAccum = 0;
+  private comboFlips = 0;
+
+  // combo
+  private comboTricks: string[] = [];
+  private comboBase = 0;
+  private lastTrickName = "";
+  private grindAccrual = 0;
+  private bankedPoints = 0;
+  private bestCombo = 0;
+  private trickCount = 0;
+  private bubbleCount = 0;
+  private lettersGot: boolean[] = [false, false, false, false, false, false];
+
+  // special / flow / power-ups
+  private special = 0;
+  private flow = false;
+  private flowT = 0;
+  private magnetT = 0;
+  private rocketT = 0;
+
+  // visuals
+  private boardRot = 0;
+  private crashT = 0;
+  private shake = 0;
+  private flashT = 0;
+  private hitstop = 0;
+  private waveT = 0;
+  private trail: { x: number; y: number }[] = [];
+  private particles: Particle[] = [];
+  private speedLines: { y: number; len: number; sp: number }[] = [];
+  private stars: { x: number; y: number; s: number }[] = [];
+  private city: number[] = [];
+  private monster: HTMLImageElement | null = null;
+  private coin: HTMLImageElement | null = null;
+  private skaterImg: HTMLImageElement | null = null; // warplet PFP override
+  private rainbow = false; // secret RAD MODE
+
+  // ghost racing
+  private runTime = 0;
+  private ghostRec: number[] = [];
+  private ghostAccum = 0;
+  private ghosts: Ghost[] = [];
+
+  constructor(container: HTMLElement, cb: SkateCallbacks = {}) {
+    this.container = container;
+    this.cb = cb;
+    this.canvas = document.createElement("canvas");
+    this.canvas.style.display = "block";
+    this.canvas.style.width = "100%";
+    this.canvas.style.height = "100%";
+    this.canvas.style.imageRendering = "pixelated";
+    container.appendChild(this.canvas);
+    const ctx = this.canvas.getContext("2d", { alpha: false });
+    if (!ctx) throw new Error("2D canvas unsupported");
+    this.ctx = ctx;
+
+    for (let i = 0; i < 70; i++) {
+      this.stars.push({ x: (i * 97.13) % 1000, y: (i * 53.7) % 100, s: (i % 3) + 1 });
+    }
+    for (let i = 0; i < 30; i++) this.city.push(14 + ((i * 37) % 30));
+    for (let i = 0; i < 14; i++) {
+      this.speedLines.push({ y: (i * 71) % 100, len: 40 + ((i * 53) % 120), sp: 1 + (i % 4) * 0.4 });
+    }
+
+    this.loadSprites();
+    this.resize(container.clientWidth, container.clientHeight);
+    this.primeCourse();
+    this.rafId = requestAnimationFrame(this.loop);
+
+    if (typeof window !== "undefined") {
+      (window as unknown as { __skateEngine?: unknown }).__skateEngine = this;
+    }
+  }
+
+  private loadSprites() {
+    const m = new Image();
+    m.onload = () => (this.monster = m);
+    m.src = "/surf/monster.png";
+    const c = new Image();
+    c.onload = () => (this.coin = c);
+    c.src = "/icon-transparent.png";
+  }
+
+  // ----------------------------------------------------------- public API
+
+  /** Tap/hold = jump on the ground (hold longer = bigger air), backflip in the air. */
+  holdStart() {
+    if (this.state === "over") return;
+    if (this.state === "idle") {
+      this.startRun();
+      return;
+    }
+    this.holding = true;
+    if (this.state === "running") {
+      // a deliberate jump off a ramp lip launches even bigger (but on-screen)
+      const rampBoost = this.rampUnder ? this.rampUnder.launch * 0.4 : 0;
+      this.rampUnder = null;
+      this.vy = Math.min(JUMP_V + rampBoost, 960);
+      this.py = Math.max(this.py, 0.1);
+      this.state = "airborne";
+      this.spinV = 0;
+      this.rotAccum = 0;
+      this.comboFlips = 0;
+      this.comboTricks.push("AIR");
+      this.comboBase += 40;
+      this.trickCount++;
+      this.emitCombo();
+      this.sfx("jump");
+    } else if (this.state === "grinding") {
+      this.vy = RAIL_POP;
+      this.state = "airborne";
+      this.currentRail = null;
+      this.spinV = 0;
+      this.rotAccum = 0;
+      this.sfx("jump");
+    }
+  }
+
+  /** Release = stop flipping / cut the jump — release in the air to land it clean. */
+  holdEnd() {
+    this.holding = false;
+  }
+
+  swipe(dir: SwipeDir) {
+    if (this.state === "idle") {
+      this.startRun();
+      return;
+    }
+    if (this.state === "airborne") {
+      const t = AIR_TRICKS[dir];
+      this.addTrick(t.name, t.base);
+      this.sfx("trick");
+    }
+  }
+
+  private startRun() {
+    this.resetRun();
+    this.state = "running";
+    this.holding = true;
+    this.cb.onStart?.();
+  }
+
+  reset() {
+    this.resetRun();
+    this.state = "running";
+    this.holding = false;
+    this.cb.onStart?.();
+  }
+
+  private resetRun() {
+    this.gaps = [];
+    this.rails = [];
+    this.ramps = [];
+    this.loops = [];
+    this.loopActive = null;
+    this.loopT = 0;
+    this.bubbles = [];
+    this.letters = [];
+    this.powers = [];
+    this.particles = [];
+    this.trail = [];
+    this.chunkCount = 0;
+    this.lastChunk = "";
+    this.restoreBreather = false;
+    this.finishX = LEVEL_LEN;
+    this.lastProgressSent = -1;
+    this.lastZone = -1;
+    this.finishLaid = false;
+    this.lives = START_LIVES;
+    this.px = 0;
+    this.py = 0;
+    this.vy = 0;
+    this.speed = BASE_SPEED;
+    this.boost = 0;
+    this.score = 0;
+    this.distance = 0;
+    this.lastScoreSent = -1;
+    this.lastDistSent = -1;
+    this.cursorX = 0;
+    this.letterIdx = 0;
+    this.nextLetterAt = 1000;
+    this.chunksSincePower = 0;
+    this.currentRail = null;
+    this.jumpedGap = null;
+    this.rampUnder = null;
+    this.spinV = 0;
+    this.rotAccum = 0;
+    this.comboFlips = 0;
+    this.comboTricks = [];
+    this.comboBase = 0;
+    this.lastTrickName = "";
+    this.grindAccrual = 0;
+    this.bankedPoints = 0;
+    this.bestCombo = 0;
+    this.trickCount = 0;
+    this.bubbleCount = 0;
+    this.lettersGot = [false, false, false, false, false, false];
+    this.special = 0;
+    this.flow = false;
+    this.flowT = 0;
+    this.magnetT = 0;
+    this.rocketT = 0;
+    this.boardRot = 0;
+    this.crashT = 0;
+    this.shake = 0;
+    this.hitstop = 0;
+    this.runTime = 0;
+    this.ghostRec = [];
+    this.ghostAccum = 0;
+    this.primeCourse();
+    this.cb.onScore?.(0);
+    this.cb.onDistance?.(0);
+    this.cb.onProgress?.(0);
+    this.cb.onZone?.(ZONES[0].name, 0, ZONES[0].accent);
+    this.cb.onLives?.(this.lives);
+    this.cb.onCombo?.(null);
+    this.cb.onSpecial?.(0);
+    this.cb.onFlow?.(false);
+    this.cb.onPower?.(null);
+    this.cb.onLetters?.([...this.lettersGot]);
+  }
+
+  /** Race against recorded runs from other players. */
+  setGhosts(ghosts: GhostInput[]) {
+    this.ghosts = ghosts.slice(0, 5).map((g, i) => ({
+      samples: g.samples,
+      color: g.color || GHOST_COLORS[i % GHOST_COLORS.length],
+      name: g.name,
+    }));
+  }
+
+  /** This run's recording (flat [px,py] pairs every GHOST_DT s). */
+  getRecording(): number[] {
+    return this.ghostRec;
+  }
+
+  /** Swap the rider sprite for a held Warplet NFT (or null to reset). */
+  setSkaterImage(img: HTMLImageElement | null) {
+    this.skaterImg = img;
+  }
+
+  /** Secret RAD MODE — rainbow trails + glow. */
+  setRainbow(on: boolean) {
+    this.rainbow = on;
+  }
+
+  resize(width: number, height: number) {
+    if (width <= 0 || height <= 0) return;
+    this.dpr = Math.min(window.devicePixelRatio || 1, 2);
+    this.W = width;
+    this.H = height;
+    this.canvas.width = Math.floor(width * this.dpr);
+    this.canvas.height = Math.floor(height * this.dpr);
+    this.groundY = Math.round(height * 0.78);
+    this.skaterX = Math.round(width * 0.28);
+  }
+
+  dispose() {
+    this.disposed = true;
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+    this.canvas.remove();
+  }
+
+  // --------------------------------------------------------- combo / score
+
+  private sfx(t: SfxType) {
+    this.cb.onSfx?.(t);
+  }
+
+  private comboMultiplier(): number {
+    return Math.max(1, this.comboTricks.length);
+  }
+
+  private emitCombo() {
+    if (this.comboTricks.length === 0) {
+      this.cb.onCombo?.(null);
+      return;
+    }
+    const mult = this.comboMultiplier();
+    this.cb.onCombo?.({
+      tricks: this.comboTricks.slice(-6),
+      base: Math.round(this.comboBase),
+      multiplier: mult,
+      live: Math.round(this.comboBase * mult * (this.flow ? 2 : 1)),
+    });
+  }
+
+  private addTrick(name: string, base: number) {
+    const repeat = name === this.lastTrickName ? 0.34 : 1;
+    this.lastTrickName = name;
+    this.comboTricks.push(name);
+    this.comboBase += base * repeat;
+    this.trickCount++;
+    this.bumpSpecial(0.08);
+    this.emitCombo();
+  }
+
+  private bumpSpecial(amount: number) {
+    if (this.flow) return;
+    this.special = Math.min(1, this.special + amount);
+    this.cb.onSpecial?.(this.special);
+    if (this.special >= 1) this.enterFlow();
+  }
+
+  private enterFlow() {
+    this.flow = true;
+    this.flowT = 7;
+    this.cb.onFlow?.(true);
+    this.sfx("flow");
+  }
+
+  private addScore(points: number) {
+    this.bankedPoints += points;
+    this.refreshScore();
+  }
+
+  private refreshScore() {
+    this.score = Math.floor(this.distance) * 8 + this.bankedPoints;
+    if (this.score !== this.lastScoreSent) {
+      this.lastScoreSent = this.score;
+      this.cb.onScore?.(this.score);
+    }
+  }
+
+  private bankCombo(landMult: number) {
+    if (this.comboTricks.length === 0) return 0;
+    const mult = this.comboMultiplier();
+    const banked = Math.round(
+      this.comboBase * mult * landMult * (this.flow ? 2 : 1)
+    );
+    if (banked > this.bestCombo) this.bestCombo = banked;
+    this.comboTricks = [];
+    this.comboBase = 0;
+    this.lastTrickName = "";
+    this.comboFlips = 0;
+    this.cb.onCombo?.(null);
+    if (banked > 0) {
+      this.addScore(banked);
+      this.cb.onBank?.(banked);
+    }
+    return banked;
+  }
+
+  private loseCombo() {
+    if (this.comboTricks.length === 0) return 0;
+    const lost = Math.round(
+      this.comboBase * this.comboMultiplier() * (this.flow ? 2 : 1)
+    );
+    this.comboTricks = [];
+    this.comboBase = 0;
+    this.lastTrickName = "";
+    this.comboFlips = 0;
+    this.cb.onCombo?.(null);
+    return lost;
+  }
+
+  // ----------------------------------------------------------- course gen
+
+  private rand(n: number): number {
+    this.waveSeed = (this.waveSeed * 1103515245 + 12345) & 0x7fffffff;
+    return (this.waveSeed / 0x7fffffff) * n;
+  }
+  private waveSeed = 20240611;
+
+  private difficulty(): number {
+    // ramps with progress through the finite level (gentle at the start)
+    return Math.min(this.px / this.finishX, 1);
+  }
+
+  private zoneIndexAt(worldX: number): number {
+    const t = worldX / this.finishX;
+    return Math.max(0, Math.min(ZONES.length - 1, Math.floor(t * ZONES.length)));
+  }
+
+  private primeCourse() {
+    this.waveSeed = 20240611;
+    this.cursorX = 760;
+    this.finishLaid = false;
+    while (this.cursorX < this.px + this.W * 2.5) this.addChunk();
+  }
+
+  private generateAhead() {
+    while (this.cursorX < this.px + this.W * 2.5 && !this.finishLaid) {
+      this.addChunk();
+    }
+    const cull = this.px - this.W;
+    this.gaps = this.gaps.filter((g) => g.x1 > cull);
+    this.rails = this.rails.filter((r) => r.x1 > cull);
+    this.ramps = this.ramps.filter((r) => r.xLip > cull);
+    this.loops = this.loops.filter((l) => l.x + 2 * l.r > cull);
+    this.bubbles = this.bubbles.filter((b) => b.x > cull && !b.taken);
+    this.letters = this.letters.filter((l) => l.x > cull && !l.taken);
+    this.powers = this.powers.filter((p) => p.x > cull && !p.taken);
+  }
+
+  private bubbleArc(cx: number, baseY: number, peak: number, n = 5, step = 34) {
+    const h = (n - 1) / 2;
+    for (let i = 0; i < n; i++) {
+      const k = i - h;
+      this.bubbles.push({ x: cx + k * step, y: baseY + peak * (1 - (k * k) / (h * h)), taken: false });
+    }
+  }
+
+  private maybeLetter(x: number, y: number) {
+    if (this.cursorX < this.nextLetterAt) return;
+    const slot = this.letterIdx % STREME_LETTERS.length;
+    this.letters.push({ x, y, ch: STREME_LETTERS[slot], slot, taken: false });
+    this.letterIdx = (this.letterIdx + 1) % STREME_LETTERS.length;
+    this.nextLetterAt = this.cursorX + 2400 + this.rand(800);
+  }
+
+  private maybePower(x: number, y: number) {
+    this.chunksSincePower++;
+    if (this.chunksSincePower < 7) return;
+    if (this.rand(1) < 0.55) return;
+    this.chunksSincePower = 0;
+    const kind: PowerKind = this.powerIdx++ % 2 === 0 ? "magnet" : "rocket";
+    this.powers.push({ x, y, kind, taken: false });
+  }
+
+  private addRamp(x0: number, size: "small" | "med" | "big"): Ramp {
+    const d = this.difficulty();
+    let len: number, h: number, launch: number;
+    // exaggerated size range: little kickers vs huge launch ramps
+    if (size === "small") { len = 76; h = 40 + d * 10; launch = 600 + d * 60; }
+    else if (size === "med") { len = 116; h = 84 + d * 16; launch = 880 + d * 90; }
+    else { len = 168; h = 150 + d * 26; launch = 1180 + d * 130; }
+    const r: Ramp = { x0, xLip: x0 + len, height: h, launch };
+    this.ramps.push(r);
+    return r;
+  }
+
+  private coinLine(x: number, y: number, n: number, step = 44) {
+    for (let i = 0; i < n; i++) this.bubbles.push({ x: x + i * step, y, taken: false });
+  }
+
+  // ---- set pieces (each lays features from cursorX and advances it) ----
+
+  private spFlat() {
+    const x = this.cursorX;
+    const len = 230 + this.rand(120);
+    this.coinLine(x + 50, 44, 6);
+    if (this.rand(1) < 0.4) this.bubbleArc(x + len / 2, 90, 80, 5, 36);
+    this.maybeLetter(x + len / 2, 120);
+    this.maybePower(x + len / 2, 150);
+    this.cursorX = x + len;
+  }
+
+  private spKickerAir(size: "small" | "med") {
+    const x = this.cursorX;
+    const r = this.addRamp(x + 110 + this.rand(50), size);
+    this.bubbleArc(r.xLip + 90, r.height + 50, 120, 5, 38);
+    this.maybeLetter(r.xLip + 90, r.height + 150);
+    this.cursorX = r.xLip + 320 + this.rand(60);
+  }
+
+  private spGap() {
+    // narrow, jumpable-without-a-ramp gap; coin arc traces the jump
+    const x = this.cursorX;
+    const d = this.difficulty();
+    const w = 90 + d * 80 + this.rand(50);
+    const gx = x + 140 + this.rand(60);
+    this.gaps.push({ x0: gx, x1: gx + w });
+    this.bubbleArc(gx + w / 2, 120, 70, 5, 34);
+    this.maybeLetter(gx + w / 2, 170);
+    this.maybePower(gx + w / 2, 200);
+    this.cursorX = gx + w + 220 + this.rand(70);
+  }
+
+  private spKickerGap() {
+    // WIDE gap — always fronted by a ramp so it's clearable (solvability rule)
+    const x = this.cursorX;
+    const d = this.difficulty();
+    const r = this.addRamp(x + 120 + this.rand(40), "med");
+    const w = 170 + d * 200 + this.rand(70);
+    const gx = r.xLip + 6;
+    this.gaps.push({ x0: gx, x1: gx + w });
+    this.bubbleArc(gx + w / 2, r.height + 30, 110, 6, 36);
+    this.maybeLetter(gx + w / 2, r.height + 170);
+    this.cursorX = gx + w + 260 + this.rand(80);
+  }
+
+  private spRail() {
+    const x = this.cursorX;
+    const len = 220 + this.rand(160);
+    const h = 66 + this.rand(22);
+    const rx = x + 130 + this.rand(60);
+    this.rails.push({ x0: rx, x1: rx + len, height: h });
+    this.coinLine(rx + 26, h + 20, 6, len / 6);
+    this.maybeLetter(rx + len / 2, h + 52);
+    this.maybePower(rx + len / 2, h + 90);
+    this.cursorX = rx + len + 200 + this.rand(70);
+  }
+
+  private spRailGap() {
+    // a gap under a rail — grind across, or jump it from the ground
+    const x = this.cursorX;
+    const len = 240 + this.rand(140);
+    const h = 64 + this.rand(20);
+    const rx = x + 130 + this.rand(50);
+    this.rails.push({ x0: rx, x1: rx + len, height: h });
+    const gx = rx + len * 0.32;
+    this.gaps.push({ x0: gx, x1: gx + Math.min(len * 0.36, 140) });
+    this.coinLine(rx + 26, h + 20, 6, len / 6);
+    this.maybeLetter(rx + len / 2, h + 52);
+    this.cursorX = rx + len + 220 + this.rand(70);
+  }
+
+  private spKickerRail() {
+    // high line: ramp launches you up to an elevated rail; ground stays clear
+    const x = this.cursorX;
+    const r = this.addRamp(x + 120 + this.rand(40), "med");
+    const rx = r.xLip + 110;
+    const len = 200 + this.rand(120);
+    const railH = r.height + 58;
+    this.rails.push({ x0: rx, x1: rx + len, height: railH });
+    this.coinLine(rx + 20, railH + 18, 5, len / 5);
+    this.maybeLetter(rx + len / 2, railH + 50);
+    this.cursorX = rx + len + 220 + this.rand(70);
+  }
+
+  private spDoubleKicker() {
+    const x = this.cursorX;
+    const r1 = this.addRamp(x + 120 + this.rand(40), "small");
+    this.bubbleArc(r1.xLip + 70, r1.height + 40, 90, 4, 34);
+    const r2 = this.addRamp(r1.xLip + 220, "small");
+    this.bubbleArc(r2.xLip + 70, r2.height + 40, 90, 4, 34);
+    this.cursorX = r2.xLip + 280 + this.rand(60);
+  }
+
+  private spQuarter() {
+    // crescendo set piece — big quarterpipe, huge air, sky-high reward
+    const x = this.cursorX;
+    const r = this.addRamp(x + 140 + this.rand(40), "big");
+    this.bubbleArc(r.xLip + 100, r.height + 60, 160, 6, 40);
+    this.maybeLetter(r.xLip + 100, r.height + 220);
+    this.powers.push({
+      x: r.xLip + 100,
+      y: r.height + 150,
+      kind: this.powerIdx++ % 2 === 0 ? "magnet" : "rocket",
+      taken: false,
+    });
+    this.chunksSincePower = 0;
+    this.cursorX = r.xLip + 440 + this.rand(80);
+  }
+
+  private spLoop() {
+    // a Sonic-style loop-the-loop: speed run-up, then a ring you ride around
+    const x = this.cursorX;
+    this.coinLine(x + 40, 44, 4, 50);
+    const lx = x + 250;
+    this.loops.push({ x: lx, r: LOOP_R });
+    this.coinLine(lx + 2 * LOOP_R + 30, 44, 4, 50);
+    this.cursorX = lx + 2 * LOOP_R + 300;
+  }
+
+  private readonly HARD = new Set(["kickerGap", "railGap", "kickerRail", "quarter"]);
+
+  private buildChunk(name: string, d: number) {
+    switch (name) {
+      case "flat": this.spFlat(); break;
+      case "kickerAir": this.spKickerAir(d > 0.5 ? "med" : "small"); break;
+      case "rail": this.spRail(); break;
+      case "gap": this.spGap(); break;
+      case "doubleKicker": this.spDoubleKicker(); break;
+      case "kickerRail": this.spKickerRail(); break;
+      case "kickerGap": this.spKickerGap(); break;
+      case "railGap": this.spRailGap(); break;
+      case "quarter": this.spQuarter(); break;
+      case "loop": this.spLoop(); break;
+      default: this.spFlat();
+    }
+  }
+
+  private addChunk() {
+    if (this.finishLaid) return;
+    this.chunkCount++;
+    const d = this.difficulty();
+
+    // reached the end → lay a calm run-in and the finish gate
+    if (this.cursorX >= this.finishX - 700) {
+      this.coinLine(this.cursorX + 40, 44, 8, 56);
+      this.cursorX = this.finishX + 200;
+      this.finishLaid = true;
+      this.lastChunk = "finish";
+      return;
+    }
+
+    // opening grace: orient to speed + controls on flat ground (no hazards)
+    if (this.chunkCount <= 3) { this.spFlat(); this.lastChunk = "flat"; return; }
+    // teach the ramp in isolation — air with no hazard after it
+    if (this.chunkCount <= 5) { this.spKickerAir("small"); this.lastChunk = "kickerAir"; return; }
+    // mandatory breather after a hard set piece (tension → release)
+    if (this.restoreBreather) { this.restoreBreather = false; this.spFlat(); this.lastChunk = "flat"; return; }
+
+    // pick from THIS ZONE's weighted mix — no immediate repeats
+    const zone = ZONES[this.zoneIndexAt(this.cursorX)];
+    const choices: [string, number][] = [];
+    for (const name in zone.mix) {
+      const w = zone.mix[name];
+      if (w > 0 && name !== this.lastChunk) choices.push([name, w]);
+    }
+    if (choices.length === 0) choices.push(["flat", 1]);
+
+    const total = choices.reduce((s, [, w]) => s + w, 0);
+    let r = this.rand(total);
+    let pick = choices[0][0];
+    for (const [name, w] of choices) {
+      if (r < w) { pick = name; break; }
+      r -= w;
+    }
+
+    this.buildChunk(pick, d);
+    if (this.HARD.has(pick)) this.restoreBreather = true;
+    this.lastChunk = pick;
+  }
+
+  private overGap(worldX: number): boolean {
+    for (const g of this.gaps) if (worldX > g.x0 && worldX < g.x1) return true;
+    return false;
+  }
+
+  private rampAt(worldX: number): Ramp | null {
+    for (const r of this.ramps) if (worldX >= r.x0 && worldX < r.xLip) return r;
+    return null;
+  }
+
+  /** Eased kicker surface (mellow base, steep lip) above the baseline. */
+  private rampSurface(r: Ramp, worldX: number): number {
+    const t = Math.min(Math.max((worldX - r.x0) / (r.xLip - r.x0), 0), 1);
+    return r.height * t * t;
+  }
+
+  /** Ground height at a world x — ramp surface, 0 flat, or NaN over a gap. */
+  private surfaceAt(worldX: number): number {
+    for (const g of this.gaps) if (worldX > g.x0 && worldX < g.x1) return NaN;
+    const r = this.rampAt(worldX);
+    if (r) return this.rampSurface(r, worldX);
+    return 0;
+  }
+
+  private railCaptureAt(worldX: number, height: number): Rail | null {
+    for (const r of this.rails) {
+      if (worldX >= r.x0 - 6 && worldX <= r.x1 && height <= r.height + 22 && height >= r.height - 18) {
+        return r;
+      }
+    }
+    return null;
+  }
+
+  // ----------------------------------------------------------- main loop
+
+  private loop = (now: number) => {
+    if (this.disposed) return;
+    const dt =
+      this.lastTime === null ? 0.016 : Math.min((now - this.lastTime) / 1000, 0.05);
+    this.lastTime = now;
+    this.waveT += dt;
+    this.update(dt);
+    this.render();
+    this.rafId = requestAnimationFrame(this.loop);
+  };
+
+  private effSpeed(): number {
+    return this.speed + this.boost + (this.rocketT > 0 ? ROCKET_SPEED : 0);
+  }
+
+  private update(dt: number) {
+    if (this.hitstop > 0) {
+      this.hitstop -= dt;
+      return; // freeze for a couple frames on a perfect landing
+    }
+
+    if (this.state === "idle" || this.state === "over") {
+      this.px += BASE_SPEED * 0.5 * dt;
+      this.py = 0;
+      this.generateAhead();
+      this.advanceVisuals(dt, BASE_SPEED * 0.5);
+      return;
+    }
+
+    // run clock + ghost recording (the clock keeps ticking through crashes)
+    this.runTime += dt;
+    this.ghostAccum += dt;
+    while (this.ghostAccum >= GHOST_DT) {
+      this.ghostAccum -= GHOST_DT;
+      this.ghostRec.push(Math.round(this.px), Math.round(this.py));
+    }
+
+    // timers
+    if (this.flow) {
+      this.flowT -= dt;
+      this.special = Math.max(0, this.flowT / 7);
+      this.cb.onSpecial?.(this.special);
+      if (this.flowT <= 0) {
+        this.flow = false;
+        this.special = 0;
+        this.cb.onFlow?.(false);
+        this.cb.onSpecial?.(0);
+      }
+    }
+    if (this.magnetT > 0) {
+      this.magnetT -= dt;
+      if (this.magnetT <= 0) this.cb.onPower?.(this.rocketT > 0 ? "rocket" : null);
+    }
+    if (this.rocketT > 0) {
+      this.rocketT -= dt;
+      if (this.rocketT <= 0) this.cb.onPower?.(this.magnetT > 0 ? "magnet" : null);
+    }
+    if (this.boost > 0) this.boost = Math.max(0, this.boost - BOOST_DECAY * dt);
+
+    if (this.state === "loop") {
+      // ride the ring (world frozen) then fire out forward with a boost
+      this.loopT += dt / LOOP_DUR;
+      if (this.rand(1) < 0.6 && this.loopActive) {
+        this.spark(this.skaterX, this.groundY - this.loopActive.r, 1);
+      }
+      if (this.loopT >= 1) {
+        const l = this.loopActive;
+        this.loopActive = null;
+        this.state = "running";
+        if (l) this.px = l.x + 2 * l.r + 30;
+        this.py = 0;
+        this.vy = 0;
+        this.boardRot = 0;
+        this.speed = Math.min(MAX_SPEED, this.speed + 90);
+        this.boost = Math.min(BOOST_CAP, this.boost + 150);
+        this.cb.onCallout?.("LOOP!", "combo");
+        this.flashT = 0.3;
+        this.sfx("perfect");
+      }
+      this.advanceVisuals(dt, 0);
+      return;
+    }
+
+    if (this.state === "crash") {
+      this.crashT += dt;
+      this.boardRot += 8 * dt;
+      this.py += this.vy * dt;
+      this.vy -= GRAVITY * dt;
+      this.advanceVisuals(dt, this.speed * 0.4);
+      if (this.shake > 0) this.shake = Math.max(0, this.shake - dt * 2.5);
+      if (this.crashT > 0.85) {
+        if (this.lives <= 0) {
+          this.gameOver(false);
+        } else {
+          // get back up past the pit and keep skating
+          const g = this.gaps.find((gp) => this.px > gp.x0 - 30 && this.px < gp.x1 + 30);
+          if (g) this.px = g.x1 + 40;
+          this.py = 0;
+          this.vy = 0;
+          this.boardRot = 0;
+          this.spinV = 0;
+          this.rampUnder = null;
+          this.speed = BASE_SPEED;
+          this.state = "running";
+        }
+      }
+      return;
+    }
+
+    // tiered acceleration: climbs fast early, plateaus near the top (Canabalt)
+    const accel = 24 * (1 - this.speed / MAX_SPEED) + 2;
+    this.speed = Math.min(MAX_SPEED, this.speed + accel * dt);
+    const eff = this.effSpeed();
+    this.px += eff * dt;
+    this.distance += (eff * dt) / METRES;
+    const dm = Math.floor(this.distance);
+    if (dm !== this.lastDistSent) {
+      this.lastDistSent = dm;
+      this.cb.onDistance?.(dm);
+    }
+    this.refreshScore();
+
+    // ---- finite-level progress, zone changes, and the finish line
+    const frac = Math.min(this.px / this.finishX, 1);
+    if (frac - this.lastProgressSent >= 0.004) {
+      this.lastProgressSent = frac;
+      this.cb.onProgress?.(frac);
+    }
+    const zi = this.zoneIndexAt(this.px);
+    if (zi !== this.lastZone) {
+      this.lastZone = zi;
+      const z = ZONES[zi];
+      this.cb.onZone?.(z.name, zi, z.accent);
+      if (this.distance > 5) {
+        this.cb.onCallout?.(z.name, "milestone");
+        this.sfx("milestone");
+      }
+    }
+    if (this.px >= this.finishX) {
+      this.finish();
+      return;
+    }
+
+    // enter a Sonic loop when we roll onto one (grounded, not in a rocket)
+    if (this.state === "running" && this.py < 12 && this.rocketT <= 0) {
+      const loop = this.loops.find((l) => this.px >= l.x && this.px < l.x + 50);
+      if (loop) {
+        this.state = "loop";
+        this.loopActive = loop;
+        this.loopT = 0;
+        this.px = loop.x;
+        this.rampUnder = null;
+        this.sfx("grind");
+        this.advanceVisuals(dt, 0);
+        return;
+      }
+    }
+
+    if (this.state === "running") {
+      if (this.rocketT > 0) {
+        this.py = 0;
+        this.boardRot *= Math.max(0, 1 - dt * 12);
+      } else {
+        const ramp = this.rampAt(this.px);
+        if (ramp) {
+          // riding up the ramp face
+          this.rampUnder = ramp;
+          this.py = this.rampSurface(ramp, this.px);
+          const slope =
+            (this.rampSurface(ramp, this.px + 5) -
+              this.rampSurface(ramp, this.px - 5)) /
+            10;
+          this.boardRot = -Math.atan(slope);
+        } else if (this.overGap(this.px)) {
+          this.rampUnder = null;
+          this.state = "airborne";
+          this.vy = -40;
+        } else if (this.rampUnder && this.px < this.rampUnder.xLip + 90) {
+          // crossed the lip (even if a fast frame skipped the exact window) —
+          // launch up + forward instead of snapping straight down to the street
+          const r = this.rampUnder;
+          this.rampUnder = null;
+          this.launchFromRamp(r);
+        } else {
+          this.rampUnder = null;
+          this.py = 0;
+          this.boardRot *= Math.max(0, 1 - dt * 12);
+        }
+      }
+    } else if (this.state === "airborne") {
+      const g = this.holding && this.vy > 0 ? JUMP_HOLD_G : GRAVITY;
+      this.vy -= g * dt;
+      this.py += this.vy * dt;
+
+      // hold to backflip; release to ease the board upright so you can stomp it
+      if (this.holding) {
+        this.spinV = Math.min(SPIN_MAX, this.spinV + SPIN_ACCEL * dt);
+        this.boardRot += this.spinV * dt;
+        this.rotAccum += this.spinV * dt;
+        while (this.rotAccum >= Math.PI * 2) {
+          this.rotAccum -= Math.PI * 2;
+          this.comboFlips++;
+          const name = FLIP_NAMES[(this.comboFlips - 1) % FLIP_NAMES.length];
+          this.comboTricks.push(name);
+          this.comboBase += FLIP_BASE;
+          this.trickCount++;
+          this.bumpSpecial(0.09);
+          this.emitCombo();
+          this.sfx("trick");
+        }
+      } else {
+        this.spinV = 0;
+        const target = Math.round(this.boardRot / (Math.PI * 2)) * (Math.PI * 2);
+        this.boardRot += (target - this.boardRot) * Math.min(dt * 11, 1);
+      }
+
+      if (this.vy <= 40 && this.rocketT <= 0) {
+        const rail = this.railCaptureAt(this.px, this.py);
+        if (rail) {
+          this.currentRail = rail;
+          this.py = rail.height;
+          this.vy = 0;
+          this.spinV = 0;
+          this.state = "grinding";
+          this.grindAccrual = 0;
+          this.boardRot = 0;
+          this.addTrick("50-50 GRIND", 120);
+          this.sfx("grind");
+        }
+      }
+
+      if (this.state === "airborne" && this.vy <= 0) {
+        const surf = this.surfaceAt(this.px);
+        if (Number.isNaN(surf)) {
+          if (this.py <= -10 && this.rocketT <= 0) this.crash();
+        } else if (this.py <= surf) {
+          this.resolveLanding(surf);
+        }
+      }
+    } else if (this.state === "grinding") {
+      const rail = this.currentRail;
+      if (!rail || this.px > rail.x1) {
+        this.currentRail = null;
+        this.state = "airborne";
+        this.vy = RAIL_END_POP;
+      } else {
+        this.py = rail.height;
+        this.grindAccrual += eff * dt;
+        while (this.grindAccrual >= 60) {
+          this.grindAccrual -= 60;
+          this.comboBase += 24;
+          this.bumpSpecial(0.012);
+          this.emitCombo();
+        }
+        if (this.rand(1) < 0.6) this.spark(this.skaterX, this.groundY - this.py, 1);
+      }
+    }
+
+    this.collect();
+    this.generateAhead();
+    this.advanceVisuals(dt, eff);
+    if (this.shake > 0) this.shake = Math.max(0, this.shake - dt * 2.5);
+    if (this.flashT > 0) this.flashT = Math.max(0, this.flashT - dt);
+  }
+
+  private launchFromRamp(r: Ramp) {
+    this.state = "airborne";
+    const norm = Math.max(
+      0,
+      Math.min(1, (this.effSpeed() - BASE_SPEED) / (MAX_SPEED - BASE_SPEED))
+    );
+    // cap so even the big ramps keep you on screen (height still varies the feel)
+    this.vy = Math.min(700, r.launch * (0.85 + 0.3 * norm));
+    this.boost = Math.min(BOOST_CAP, this.boost + 55); // ramps fling you forward
+    this.spinV = 0;
+    this.rotAccum = 0;
+    this.comboFlips = 0;
+    this.comboTricks.push("AIR");
+    this.comboBase += 40;
+    this.trickCount++;
+    this.emitCombo();
+    this.sfx("jump");
+    const sy = this.groundY - this.py;
+    for (let i = 0; i < 6; i++) {
+      this.particles.push({
+        x: this.skaterX, y: sy, vx: this.rand(80) - 40, vy: -this.rand(110),
+        life: 0.35, maxLife: 0.35, color: C_CYAN, size: 2,
+      });
+    }
+  }
+
+  private resolveLanding(surf: number) {
+    this.py = surf;
+    this.spinV = 0;
+    this.rampUnder = null;
+    this.state = "running";
+
+    // how upright is the board? small offset = clean
+    let off = Math.abs(((this.boardRot % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2));
+    off = Math.min(off, Math.PI * 2 - off);
+    const flipped = this.comboFlips > 0;
+
+    // near-miss bonus if we just barely cleared a gap
+    let near = false;
+    if (this.jumpedGap && this.px - this.jumpedGap.x1 < 55 && this.px > this.jumpedGap.x1) {
+      near = true;
+    }
+    this.jumpedGap = null;
+
+    if (off < 0.38) {
+      // CLEAN — boost + payout (PERFECT if you actually flipped)
+      this.boardRot = 0;
+      const banked = this.bankCombo(flipped ? 1.6 : 1.1);
+      this.boost = Math.min(BOOST_CAP, this.boost + (flipped ? BOOST_PERFECT : BOOST_SICK));
+      if (flipped) {
+        this.cb.onCallout?.("PERFECT!", "perfect");
+        this.sfx("perfect");
+        this.shake = 0.7;
+        this.hitstop = 0.05;
+        this.flashT = 0.25;
+      } else {
+        this.sfx("land");
+        this.shake = 0.3;
+      }
+      this.landBurst(banked > 800 ? 16 : 9, C_GOLD);
+    } else if (off < 0.95) {
+      // SICK — clean enough, small boost
+      this.boardRot = 0;
+      this.bankCombo(1.2);
+      this.boost = Math.min(BOOST_CAP, this.boost + BOOST_SICK * 0.6);
+      this.cb.onCallout?.("SICK!", "sick");
+      this.sfx("land");
+      this.shake = 0.35;
+      this.landBurst(8, C_CYAN);
+    } else {
+      // SLOPPY — landed mid-flip: keep some points, lose speed, no boost
+      this.boardRot = 0;
+      this.bankCombo(0.4);
+      this.speed = Math.max(BASE_SPEED, this.speed * 0.8);
+      this.cb.onCallout?.("SLOPPY", "sloppy");
+      this.sfx("land");
+      this.shake = 0.4;
+      this.landBurst(6, C_PINK);
+    }
+
+    if (near) {
+      this.addScore(400);
+      this.cb.onBank?.(400);
+      this.cb.onCallout?.("CLOSE!", "close");
+      this.boost = Math.min(BOOST_CAP, this.boost + 70);
+    }
+  }
+
+  private landBurst(n: number, color: string) {
+    const sy = this.groundY;
+    for (let i = 0; i < n; i++) {
+      this.particles.push({
+        x: this.skaterX + (this.rand(26) - 13),
+        y: sy,
+        vx: this.rand(120) - 60,
+        vy: -this.rand(150),
+        life: 0.45,
+        maxLife: 0.45,
+        color,
+        size: 2 + Math.floor(this.rand(2)),
+      });
+    }
+  }
+
+  private crash() {
+    const lost = this.loseCombo() ?? 0;
+    this.lives = Math.max(0, this.lives - 1);
+    this.cb.onLives?.(this.lives);
+    this.state = "crash";
+    this.crashT = 0;
+    this.vy = 240;
+    this.shake = 1;
+    this.sfx("crash");
+    this.cb.onBail?.(lost);
+    const sy = this.groundY - this.py;
+    for (let i = 0; i < 18; i++) {
+      this.particles.push({
+        x: this.skaterX,
+        y: sy,
+        vx: this.rand(260) - 130,
+        vy: -this.rand(260),
+        life: 0.7,
+        maxLife: 0.7,
+        color: i % 2 ? C_PINK : "#ffffff",
+        size: 3,
+      });
+    }
+  }
+
+  private collect() {
+    const magnet = this.magnetT > 0;
+    for (const b of this.bubbles) {
+      if (b.taken) continue;
+      if (magnet && Math.abs(b.x - this.px) < MAGNET_R && Math.abs(b.y - this.py) < MAGNET_R) {
+        const k = Math.min(1, (this.effSpeed() + 200) / 600);
+        b.x += (this.px - b.x) * 0.22 * (1 + k);
+        b.y += (this.py - b.y) * 0.22 * (1 + k);
+      }
+      if (Math.abs(b.x - this.px) < 28 && Math.abs(b.y - this.py) < 34) {
+        b.taken = true;
+        this.bubbleCount++;
+        this.comboBase += 60;
+        this.comboTricks.push("$STREME");
+        this.trickCount++;
+        this.bumpSpecial(0.05);
+        this.emitCombo();
+        this.sfx("bubble");
+        const sy = this.groundY - b.y;
+        for (let i = 0; i < 5; i++) {
+          this.particles.push({
+            x: this.skaterX, y: sy, vx: this.rand(120) - 60, vy: -this.rand(120),
+            life: 0.4, maxLife: 0.4, color: C_TEAL, size: 2,
+          });
+        }
+      }
+    }
+    for (const p of this.powers) {
+      if (p.taken) continue;
+      if (Math.abs(p.x - this.px) < 32 && Math.abs(p.y - this.py) < 40) {
+        p.taken = true;
+        this.sfx("power");
+        this.flashT = 0.35;
+        if (p.kind === "magnet") {
+          this.magnetT = MAGNET_T;
+          this.cb.onPower?.("magnet");
+          this.cb.onCallout?.("MAGNET!", "power");
+        } else {
+          this.rocketT = ROCKET_T;
+          this.boost = BOOST_CAP;
+          this.cb.onPower?.("rocket");
+          this.cb.onCallout?.("ROCKET!", "power");
+          this.shake = 0.6;
+        }
+      }
+    }
+    for (const l of this.letters) {
+      if (l.taken) continue;
+      if (Math.abs(l.x - this.px) < 34 && Math.abs(l.y - this.py) < 42) {
+        l.taken = true;
+        // light the exact STREME slot this letter belongs to (so the HUD
+        // matches the letter you actually grabbed, even out of order)
+        this.lettersGot[l.slot] = true;
+        this.cb.onLetters?.([...this.lettersGot]);
+        this.comboBase += 250;
+        this.comboTricks.push(`LETTER ${l.ch}`);
+        this.trickCount++;
+        this.bumpSpecial(0.18);
+        this.emitCombo();
+        this.sfx("letter");
+        this.flashT = 0.4;
+        if (this.lettersGot.every(Boolean)) {
+          this.addScore(5000);
+          this.cb.onBank?.(5000);
+          this.cb.onAllLetters?.();
+          this.cb.onCallout?.("S-T-R-E-M-E!", "combo");
+          this.lettersGot = [false, false, false, false, false, false];
+          this.cb.onLetters?.([...this.lettersGot]);
+          this.enterFlow();
+        }
+      }
+    }
+    // remember a gap we're flying over for the near-miss check on landing
+    for (const g of this.gaps) {
+      if (this.px > g.x0 - 10 && this.px < g.x1) this.jumpedGap = g;
+    }
+  }
+
+  private gameOver(finished: boolean) {
+    this.state = "over";
+    this.cb.onGameOver?.({
+      score: this.score,
+      bestCombo: this.bestCombo,
+      letters: this.lettersGot.filter(Boolean).length,
+      bubbles: this.bubbleCount,
+      tricks: this.trickCount,
+      distance: Math.floor(this.distance),
+      finished,
+    });
+  }
+
+  private finish() {
+    // crossed the finish line — bank the run, completion bonus, celebrate
+    this.bankCombo(1);
+    this.cb.onProgress?.(1);
+    this.addScore(10000);
+    this.cb.onBank?.(10000);
+    this.cb.onCallout?.("LEVEL COMPLETE!", "combo");
+    this.flashT = 0.6;
+    this.gameOver(true);
+  }
+
+  // ----------------------------------------------------------- visuals
+
+  private advanceVisuals(dt: number, speed: number) {
+    const feetY = this.groundY - this.py;
+    this.trail.unshift({ x: this.skaterX, y: feetY });
+    if (this.trail.length > 16) this.trail.pop();
+    for (let i = 1; i < this.trail.length; i++) this.trail[i].x -= speed * dt;
+    for (let i = this.particles.length - 1; i >= 0; i--) {
+      const p = this.particles[i];
+      p.x -= speed * dt;
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      p.vy += 380 * dt;
+      p.life -= dt;
+      if (p.life <= 0) this.particles.splice(i, 1);
+    }
+  }
+
+  private spark(x: number, y: number, n: number) {
+    for (let i = 0; i < n; i++) {
+      this.particles.push({
+        x, y, vx: -this.rand(140) - 40, vy: -this.rand(160),
+        life: 0.35, maxLife: 0.35, color: this.rand(1) > 0.5 ? C_CYAN : C_PINK, size: 2,
+      });
+    }
+  }
+
+  private sx(worldX: number): number {
+    return worldX - (this.px - this.skaterX);
+  }
+
+  private render() {
+    const ctx = this.ctx;
+    const W = this.W;
+    const H = this.H;
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+
+    const shx = this.shake > 0 ? (this.rand(1) - 0.5) * this.shake * 11 : 0;
+    const shy = this.shake > 0 ? (this.rand(1) - 0.5) * this.shake * 11 : 0;
+    ctx.save();
+    ctx.translate(shx, shy);
+
+    this.drawSky(ctx, W, H);
+    this.drawSpeedLines(ctx, W);
+    this.drawStreet(ctx, W, H);
+    this.drawRamps(ctx);
+    this.drawLoops(ctx);
+    this.drawRails(ctx);
+    this.drawFinish(ctx);
+    this.drawCollectibles(ctx);
+    this.drawGhosts(ctx);
+    this.drawTrail(ctx);
+    this.drawSkater(ctx);
+
+    ctx.restore();
+
+    if (this.rocketT > 0) {
+      ctx.fillStyle = `rgba(253,230,138,${0.06 + 0.04 * Math.sin(this.waveT * 14)})`;
+      ctx.fillRect(0, 0, W, H);
+    } else if (this.flow) {
+      ctx.fillStyle = `rgba(103,232,249,${0.04 + 0.03 * Math.sin(this.waveT * 8)})`;
+      ctx.fillRect(0, 0, W, H);
+    }
+    if (this.flashT > 0) {
+      ctx.fillStyle = `rgba(255,255,255,${this.flashT * 0.4})`;
+      ctx.fillRect(0, 0, W, H);
+    }
+    this.drawScanlines(ctx, W, H);
+  }
+
+  private drawSpeedLines(ctx: CanvasRenderingContext2D, W: number) {
+    const intensity = Math.min(1, (this.boost + (this.rocketT > 0 ? 300 : 0)) / 260);
+    if (intensity <= 0.02 && this.state !== "crash") return;
+    ctx.strokeStyle = this.rocketT > 0 ? C_GOLD : C_CYAN;
+    ctx.lineWidth = 2;
+    for (const l of this.speedLines) {
+      const y = (l.y / 100) * this.groundY;
+      const x = ((-(this.px * l.sp * 1.5) % (W + 200)) + W + 200) % (W + 200);
+      ctx.globalAlpha = intensity * 0.5;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x - l.len * (0.6 + intensity), y);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  private lerpRGB(a: RGB, b: RGB, t: number): string {
+    return `rgb(${Math.round(a[0] + (b[0] - a[0]) * t)},${Math.round(
+      a[1] + (b[1] - a[1]) * t
+    )},${Math.round(a[2] + (b[2] - a[2]) * t)})`;
+  }
+
+  /** Interpolated zone palette slot (0..3) by progress through the level. */
+  private skyCol(slot: number): string {
+    const t = Math.min(this.px / this.finishX, 1) * (ZONES.length - 1);
+    const i = Math.min(ZONES.length - 2, Math.max(0, Math.floor(t)));
+    return this.lerpRGB(ZONES[i].pal.sky[slot], ZONES[i + 1].pal.sky[slot], t - i);
+  }
+  private sunCol(slot: number): string {
+    const t = Math.min(this.px / this.finishX, 1) * (ZONES.length - 1);
+    const i = Math.min(ZONES.length - 2, Math.max(0, Math.floor(t)));
+    return this.lerpRGB(ZONES[i].pal.sun[slot], ZONES[i + 1].pal.sun[slot], t - i);
+  }
+
+  private drawSky(ctx: CanvasRenderingContext2D, W: number, H: number) {
+    const g = ctx.createLinearGradient(0, 0, 0, this.groundY);
+    g.addColorStop(0, this.skyCol(0));
+    g.addColorStop(0.45, this.skyCol(1));
+    g.addColorStop(0.78, this.skyCol(2));
+    g.addColorStop(1, this.skyCol(3));
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, W, this.groundY);
+
+    ctx.fillStyle = "#ffffff";
+    const starScroll = (this.px * 0.04) % 1000;
+    for (const s of this.stars) {
+      let x = (((s.x - starScroll) % 1000) + 1000) % 1000;
+      x = (x / 1000) * W;
+      const y = (s.y / 100) * (this.groundY * 0.7);
+      ctx.globalAlpha = 0.5 + 0.5 * Math.sin(this.waveT * 2 + s.x);
+      ctx.fillRect(Math.round(x), Math.round(y), s.s, s.s);
+    }
+    ctx.globalAlpha = 1;
+
+    const sunX = W * 0.62;
+    const sunY = this.groundY - H * 0.2;
+    const sunR = Math.min(W, H) * 0.16;
+    const sg = ctx.createLinearGradient(0, sunY - sunR, 0, sunY + sunR);
+    sg.addColorStop(0, this.sunCol(0));
+    sg.addColorStop(0.45, this.sunCol(1));
+    sg.addColorStop(0.75, this.sunCol(2));
+    sg.addColorStop(1, this.sunCol(3));
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(sunX, sunY, sunR, 0, Math.PI * 2);
+    ctx.clip();
+    ctx.fillStyle = sg;
+    ctx.fillRect(sunX - sunR, sunY - sunR, sunR * 2, sunR * 2);
+    ctx.fillStyle = this.skyCol(1);
+    for (let i = 0; i < 7; i++) {
+      const yy = sunY + i * (sunR / 5) - 2;
+      ctx.fillRect(sunX - sunR, yy, sunR * 2, Math.max(2, i));
+    }
+    ctx.restore();
+
+    const bw = 34;
+    const span = this.city.length * bw;
+    const cityScroll = (this.px * 0.1) % span;
+    ctx.globalAlpha = 0.5;
+    ctx.fillStyle = "#150a33";
+    for (let i = 0; i < this.city.length; i++) {
+      let x = i * bw - cityScroll;
+      x = ((x % span) + span) % span;
+      const bh = this.city[i] + 8;
+      ctx.fillRect(Math.round(x) - bw, this.groundY - bh, bw - 5, bh);
+    }
+    ctx.globalAlpha = 1;
+    const haze = ctx.createLinearGradient(0, this.groundY - 64, 0, this.groundY);
+    haze.addColorStop(0, "rgba(12,6,28,0)");
+    haze.addColorStop(1, "rgba(12,6,28,0.55)");
+    ctx.fillStyle = haze;
+    ctx.fillRect(0, this.groundY - 64, W, 64);
+  }
+
+  private drawStreet(ctx: CanvasRenderingContext2D, W: number, H: number) {
+    ctx.fillStyle = "#140a2e";
+    ctx.fillRect(0, this.groundY, W, H - this.groundY);
+
+    ctx.strokeStyle = "rgba(45,212,191,0.3)";
+    ctx.lineWidth = 1;
+    const gridScroll = (this.px * 0.6) % 60;
+    for (let i = 1; i <= 8; i++) {
+      const t = i / 8;
+      const y = this.groundY + Math.pow(t, 1.7) * (H - this.groundY);
+      ctx.globalAlpha = 0.12 + t * 0.28;
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(W, y);
+      ctx.stroke();
+    }
+    for (let i = -1; i < 24; i++) {
+      const bx = i * 60 - gridScroll;
+      ctx.globalAlpha = 0.16;
+      ctx.beginPath();
+      ctx.moveTo(W / 2 + (bx - W / 2) * 0.55, this.groundY);
+      ctx.lineTo(bx, H);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // glowing street edge — broken by gaps
+    ctx.fillStyle = C_TEAL;
+    ctx.shadowColor = C_TEAL;
+    ctx.shadowBlur = 8;
+    let cx = 0;
+    const edges: [number, number][] = [];
+    for (const gap of this.gaps) {
+      const g0 = this.sx(gap.x0);
+      const g1 = this.sx(gap.x1);
+      if (g1 < 0 || g0 > W) continue;
+      edges.push([g0, g1]);
+    }
+    edges.sort((a, b) => a[0] - b[0]);
+    for (const [g0, g1] of edges) {
+      if (g0 > cx) ctx.fillRect(cx, this.groundY - 2, g0 - cx, 3);
+      cx = Math.max(cx, g1);
+    }
+    if (cx < W) ctx.fillRect(cx, this.groundY - 2, W - cx, 3);
+    ctx.shadowBlur = 0;
+
+    for (const gap of this.gaps) {
+      const g0 = this.sx(gap.x0);
+      const g1 = this.sx(gap.x1);
+      if (g1 < -20 || g0 > W + 20) continue;
+      ctx.fillStyle = "#05030f";
+      ctx.fillRect(g0, this.groundY, g1 - g0, H - this.groundY);
+      ctx.fillStyle = C_PINK;
+      ctx.shadowColor = C_PINK;
+      ctx.shadowBlur = 8;
+      ctx.fillRect(g0 - 3, this.groundY - 3, 3, 16);
+      ctx.fillRect(g1, this.groundY - 3, 3, 16);
+      ctx.shadowBlur = 0;
+    }
+  }
+
+  private drawRamps(ctx: CanvasRenderingContext2D) {
+    for (const r of this.ramps) {
+      const x0 = this.sx(r.x0);
+      const xL = this.sx(r.xLip);
+      if (xL < -40 || x0 > this.W + 40) continue;
+      const STEPS = 12;
+      const pts: [number, number][] = [];
+      for (let i = 0; i <= STEPS; i++) {
+        const wx = r.x0 + (r.xLip - r.x0) * (i / STEPS);
+        pts.push([this.sx(wx), this.groundY - this.rampSurface(r, wx)]);
+      }
+      // body
+      ctx.beginPath();
+      ctx.moveTo(x0, this.groundY);
+      for (const [px, py] of pts) ctx.lineTo(px, py);
+      ctx.lineTo(xL, this.groundY);
+      ctx.closePath();
+      const rg = ctx.createLinearGradient(x0, this.groundY, xL, this.groundY - r.height);
+      rg.addColorStop(0, "#241552");
+      rg.addColorStop(1, "#4a2391");
+      ctx.fillStyle = rg;
+      ctx.fill();
+      // glowing surface curve
+      ctx.strokeStyle = C_CYAN;
+      ctx.shadowColor = C_CYAN;
+      ctx.shadowBlur = 8;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (const [px, py] of pts) ctx.lineTo(px, py);
+      ctx.stroke();
+      // bright lip cap (the launch edge)
+      ctx.shadowBlur = 12;
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(xL - 5, this.groundY - r.height - 3, 7, 5);
+      ctx.shadowBlur = 0;
+    }
+  }
+
+  private drawFinish(ctx: CanvasRenderingContext2D) {
+    const fx = this.sx(this.finishX);
+    if (fx < -90 || fx > this.W + 90) return;
+    const base = this.groundY;
+    const top = base - 170;
+    const cw = 9;
+    // checkered banner
+    for (let row = 0; row < 3; row++) {
+      for (let c = 0; c < 6; c++) {
+        ctx.fillStyle = (row + c) % 2 ? "#ffffff" : "#0c0626";
+        ctx.fillRect(fx + c * cw, top + row * cw, cw, cw);
+      }
+    }
+    // glowing posts
+    ctx.strokeStyle = C_GOLD;
+    ctx.shadowColor = C_GOLD;
+    ctx.shadowBlur = 12;
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.moveTo(fx, top);
+    ctx.lineTo(fx, base);
+    ctx.moveTo(fx + 54, top);
+    ctx.lineTo(fx + 54, base);
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = C_GOLD;
+    ctx.font = "bold 13px ui-monospace, monospace";
+    ctx.textAlign = "center";
+    ctx.fillText("FINISH", fx + 27, top - 10);
+    ctx.textAlign = "left";
+  }
+
+  private drawLoops(ctx: CanvasRenderingContext2D) {
+    for (const l of this.loops) {
+      const cx = this.sx(l.x + l.r);
+      if (cx < -l.r - 50 || cx > this.W + l.r + 50) continue;
+      const cy = this.groundY - l.r;
+      const pulse = 0.6 + 0.4 * Math.sin(this.waveT * 4 + l.x * 0.01);
+      ctx.save();
+      // outer neon ring
+      ctx.strokeStyle = C_PINK;
+      ctx.shadowColor = C_PINK;
+      ctx.shadowBlur = 14 * pulse;
+      ctx.lineWidth = 7;
+      ctx.beginPath();
+      ctx.arc(cx, cy, l.r, 0, Math.PI * 2);
+      ctx.stroke();
+      // inner ring
+      ctx.shadowColor = C_CYAN;
+      ctx.strokeStyle = C_CYAN;
+      ctx.lineWidth = 2;
+      ctx.shadowBlur = 8;
+      ctx.beginPath();
+      ctx.arc(cx, cy, l.r - 9, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+    }
+  }
+
+  private drawRails(ctx: CanvasRenderingContext2D) {
+    for (const r of this.rails) {
+      const x0 = this.sx(r.x0);
+      const x1 = this.sx(r.x1);
+      if (x1 < -40 || x0 > this.W + 40) continue;
+      const y = this.groundY - r.height;
+      ctx.fillStyle = "#3a2a6e";
+      ctx.fillRect(x0 + 2, y, 4, r.height);
+      ctx.fillRect(x1 - 6, y, 4, r.height);
+      const pulse = 0.6 + 0.4 * Math.sin(this.waveT * 5 + r.x0 * 0.01);
+      ctx.fillStyle = C_PINK;
+      ctx.shadowColor = C_PINK;
+      ctx.shadowBlur = 10 * pulse;
+      ctx.fillRect(x0, y - 3, x1 - x0, 4);
+      ctx.shadowBlur = 0;
+    }
+  }
+
+  private drawCollectibles(ctx: CanvasRenderingContext2D) {
+    for (const b of this.bubbles) {
+      if (b.taken) continue;
+      const x = this.sx(b.x);
+      if (x < -30 || x > this.W + 30) continue;
+      const y = this.groundY - b.y + Math.sin(this.waveT * 3 + b.x * 0.02) * 3;
+      ctx.save();
+      ctx.shadowColor = C_TEAL;
+      ctx.shadowBlur = 10;
+      if (this.coin) {
+        const s = 22;
+        ctx.drawImage(this.coin, x - s / 2, y - s / 2, s, s);
+      } else {
+        ctx.fillStyle = C_TEAL;
+        ctx.beginPath();
+        ctx.arc(x, y, 9, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+    // power-ups
+    for (const p of this.powers) {
+      if (p.taken) continue;
+      const x = this.sx(p.x);
+      if (x < -30 || x > this.W + 30) continue;
+      const y = this.groundY - p.y + Math.sin(this.waveT * 3 + p.x * 0.02) * 4;
+      const col = p.kind === "rocket" ? C_GOLD : C_CYAN;
+      ctx.save();
+      ctx.shadowColor = col;
+      ctx.shadowBlur = 16;
+      ctx.fillStyle = "rgba(12,6,38,0.9)";
+      ctx.beginPath();
+      ctx.arc(x, y, 16, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.lineWidth = 2.5;
+      ctx.strokeStyle = col;
+      ctx.stroke();
+      ctx.fillStyle = col;
+      ctx.font = "bold 16px ui-monospace, monospace";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(p.kind === "rocket" ? "🚀" : "🧲", x, y + 1);
+      ctx.restore();
+    }
+    for (const l of this.letters) {
+      if (l.taken) continue;
+      const x = this.sx(l.x);
+      if (x < -30 || x > this.W + 30) continue;
+      const y = this.groundY - l.y + Math.sin(this.waveT * 2.5 + l.x * 0.02) * 4;
+      ctx.save();
+      ctx.shadowColor = C_CYAN;
+      ctx.shadowBlur = 14;
+      ctx.fillStyle = "rgba(12,6,38,0.85)";
+      ctx.fillRect(x - 14, y - 16, 28, 32);
+      ctx.strokeStyle = C_CYAN;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x - 14, y - 16, 28, 32);
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "bold 22px ui-monospace, monospace";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(l.ch, x, y + 1);
+      ctx.restore();
+    }
+    ctx.textAlign = "left";
+    ctx.textBaseline = "alphabetic";
+  }
+
+  private drawTrail(ctx: CanvasRenderingContext2D) {
+    if (this.state === "idle" || this.state === "over") return;
+    const offs = [-3, 0, 3];
+    const rocket = this.rocketT > 0;
+    const rainbow = this.flow || rocket || this.rainbow;
+    for (let t = 0; t < 3; t++) {
+      ctx.beginPath();
+      let started = false;
+      for (let i = 0; i < this.trail.length; i++) {
+        const p = this.trail[i];
+        const yy = p.y + offs[t];
+        if (!started) {
+          ctx.moveTo(p.x, yy);
+          started = true;
+        } else ctx.lineTo(p.x, yy);
+      }
+      ctx.strokeStyle = rainbow
+        ? FLOW_COLORS[(t + Math.floor(this.waveT * 12)) % FLOW_COLORS.length]
+        : TRAIL_COLORS[t];
+      ctx.globalAlpha = rocket ? 0.8 : 0.55;
+      ctx.lineWidth = rocket ? 3 : 2;
+      ctx.shadowColor = ctx.strokeStyle as string;
+      ctx.shadowBlur = rocket ? 12 : 6;
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    ctx.shadowBlur = 0;
+    for (const p of this.particles) {
+      ctx.globalAlpha = Math.max(0, p.life / p.maxLife);
+      ctx.fillStyle = p.color;
+      ctx.fillRect(Math.round(p.x), Math.round(p.y), p.size, p.size);
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  private drawSkater(ctx: CanvasRenderingContext2D) {
+    let x = this.skaterX;
+    let y = this.groundY - this.py;
+    let rot = this.boardRot;
+    if (this.state === "loop" && this.loopActive) {
+      // ride around the ring: bottom → right → top (upside down) → left → bottom
+      const phi = this.loopT * Math.PI * 2;
+      const cx = this.sx(this.loopActive.x + this.loopActive.r);
+      const cy = this.groundY - this.loopActive.r;
+      x = cx + this.loopActive.r * Math.sin(phi);
+      y = cy + this.loopActive.r * Math.cos(phi);
+      rot = phi;
+    }
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(rot);
+
+    // magnet aura
+    if (this.magnetT > 0) {
+      ctx.save();
+      ctx.strokeStyle = `rgba(103,232,249,${0.3 + 0.2 * Math.sin(this.waveT * 6)})`;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(0, -8, 30 + 3 * Math.sin(this.waveT * 6), 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    ctx.save();
+    ctx.shadowColor = this.flow || this.rocketT > 0 || this.rainbow ? "#fde68a" : C_CYAN;
+    ctx.shadowBlur = this.flow || this.rocketT > 0 ? 22 : 14;
+    ctx.fillStyle = this.flow || this.rocketT > 0 ? "rgba(253,230,138,0.5)" : "rgba(103,232,249,0.4)";
+    ctx.beginPath();
+    ctx.ellipse(0, 6, 22, 7, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
+
+    ctx.fillStyle = "#f8fafc";
+    ctx.fillRect(-20, 4, 40, 5);
+    ctx.fillStyle = C_INDIGO;
+    ctx.fillRect(-20, 9, 40, 2);
+    ctx.fillStyle = "#fbbf24";
+    ctx.fillRect(-15, 10, 5, 5);
+    ctx.fillRect(10, 10, 5, 5);
+
+    const rider = this.skaterImg || this.monster;
+    if (rider) {
+      const s = 40;
+      ctx.imageSmoothingEnabled = !!this.skaterImg;
+      ctx.drawImage(rider, -s / 2, -s + 4, s, s);
+    } else {
+      ctx.fillStyle = C_TEAL;
+      ctx.fillRect(-12, -28, 24, 30);
+    }
+    ctx.restore();
+  }
+
+  /** Translucent racers replaying other players' recorded runs. */
+  private drawGhosts(ctx: CanvasRenderingContext2D) {
+    if (this.ghosts.length === 0 || this.state === "idle" || this.state === "over") {
+      return;
+    }
+    const t = this.runTime / GHOST_DT;
+    const i0 = Math.floor(t);
+    const f = t - i0;
+    for (const g of this.ghosts) {
+      const n = g.samples.length / 2;
+      if (n < 2) continue;
+      const ia = Math.min(i0, n - 1);
+      const ib = Math.min(i0 + 1, n - 1);
+      const gx = g.samples[ia * 2] + (g.samples[ib * 2] - g.samples[ia * 2]) * f;
+      const gy =
+        g.samples[ia * 2 + 1] + (g.samples[ib * 2 + 1] - g.samples[ia * 2 + 1]) * f;
+      const px = this.sx(gx);
+      if (px < -40 || px > this.W + 40) continue;
+      const py = this.groundY - gy;
+      ctx.save();
+      ctx.translate(px, py);
+      ctx.globalAlpha = 0.4;
+      ctx.shadowColor = g.color;
+      ctx.shadowBlur = 8;
+      ctx.fillStyle = g.color;
+      ctx.beginPath();
+      ctx.ellipse(0, 6, 15, 5, 0, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+      ctx.fillStyle = "#cbd5e1";
+      ctx.fillRect(-15, 4, 30, 4);
+      if (this.monster) {
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(this.monster, -16, -28, 32, 32);
+      }
+      ctx.globalAlpha = 1;
+      if (g.name) {
+        ctx.globalAlpha = 0.85;
+        ctx.fillStyle = g.color;
+        ctx.font = "bold 9px ui-monospace, monospace";
+        ctx.textAlign = "center";
+        ctx.fillText(g.name.slice(0, 12), 0, -32);
+        ctx.textAlign = "left";
+        ctx.globalAlpha = 1;
+      }
+      ctx.restore();
+    }
+  }
+
+  private drawScanlines(ctx: CanvasRenderingContext2D, W: number, H: number) {
+    ctx.globalAlpha = 0.12;
+    ctx.fillStyle = "#000000";
+    for (let y = 0; y < H; y += 3) ctx.fillRect(0, y, W, 1);
+    ctx.globalAlpha = 1;
+    const v = ctx.createRadialGradient(
+      W / 2, H * 0.45, Math.min(W, H) * 0.3, W / 2, H * 0.5, Math.max(W, H) * 0.75
+    );
+    v.addColorStop(0, "rgba(0,0,0,0)");
+    v.addColorStop(1, "rgba(4,2,16,0.55)");
+    ctx.fillStyle = v;
+    ctx.fillRect(0, 0, W, H);
+  }
+}

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -1250,9 +1250,12 @@ export class SkateGameEngine {
     }
     this.refreshScore();
 
-    // ---- countdown clock: drains in real time (faster as it gets harder),
-    //      recharged by great plays. Zero = the run is over.
-    this.timeLeft -= (1 + this.difficulty() * 0.35) * dt;
+    // ---- countdown clock: drains in real time and SPEEDS UP the longer you
+    //      last (1× at the drop-in → up to 3.5× deep into a run), so late runs
+    //      demand constant trick-chaining — a natural soft cap for an endless
+    //      game. Recharged by great plays; zero = the run is over.
+    const drainRate = Math.min(3.5, 1 + this.runTime / 90);
+    this.timeLeft -= drainRate * dt;
     if (this.timeLeft <= 0) {
       this.timeLeft = 0;
       this.emitTime();

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -144,7 +144,13 @@ interface WarpletInfo {
   warplets: WarpletItem[];
 }
 
-const ZONE_COLORS = ["#67e8f9", "#2dd4bf", "#fb923c", "#c084fc", "#fbbf24"];
+const ZONE_NAMES = [
+  "NEON DOWNTOWN",
+  "GRIND DISTRICT",
+  "GAP CITY",
+  "VERT HEIGHTS",
+  "OVERDRIVE",
+];
 
 const CALLOUT_COLORS: Record<CalloutKind, string> = {
   perfect: "#fde68a",
@@ -180,7 +186,6 @@ export default function StremeSkateGame({
   const [zone, setZone] = useState<{ name: string; index: number; accent: string }>(
     { name: "NEON DOWNTOWN", index: 0, accent: "#67e8f9" }
   );
-  const [lives, setLives] = useState(3);
   const [special, setSpecial] = useState(0);
   const [flow, setFlow] = useState(false);
   const [letters, setLetters] = useState<boolean[]>([
@@ -373,6 +378,15 @@ export default function StremeSkateGame({
     [playTone, haptic]
   );
 
+  // grind audio rises in pitch the longer you hold the rail (THPS/OlliOlli feel)
+  const handleGrindTick = useCallback(
+    (level: number) => {
+      const f = Math.min(170 + level * 62, 560);
+      playTone(f, 0.06, "sawtooth", 0.035);
+    },
+    [playTone]
+  );
+
   const showToast = useCallback((text: string, ms = 1600) => {
     setToast(text);
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
@@ -473,6 +487,7 @@ export default function StremeSkateGame({
     handleAllLetters,
     handleGameOver,
     handleSfx,
+    handleGrindTick,
     showToast,
     showCallout,
   });
@@ -481,6 +496,7 @@ export default function StremeSkateGame({
     handleAllLetters,
     handleGameOver,
     handleSfx,
+    handleGrindTick,
     showToast,
     showCallout,
   };
@@ -501,7 +517,6 @@ export default function StremeSkateGame({
         setBank(null);
         setDistance(0);
         setProgress(0);
-        setLives(3);
         setSpecial(0);
         setFlow(false);
         setLetters([false, false, false, false, false, false]);
@@ -529,7 +544,7 @@ export default function StremeSkateGame({
       onDistance: (d) => setDistance(d),
       onProgress: (p) => setProgress(p),
       onZone: (name, index, accent) => setZone({ name, index, accent }),
-      onLives: (n) => setLives(n),
+      onGrindTick: (lvl) => cbRef.current.handleGrindTick(lvl),
       onCallout: (text, kind) => cbRef.current.showCallout(text, kind),
       onPower: (kind) => setPower(kind),
       onSfx: (t) => cbRef.current.handleSfx(t),
@@ -901,19 +916,11 @@ export default function StremeSkateGame({
             <div className="font-mono text-xs font-semibold text-cyan-300">
               {distance.toLocaleString()}m
             </div>
-            <div className="mt-0.5 flex gap-0.5">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <span
-                  key={i}
-                  className="text-xs leading-none"
-                  style={{
-                    color: i < lives ? "#fb7185" : "rgba(255,255,255,0.18)",
-                    textShadow: i < lives ? "0 0 6px rgba(244,63,94,0.8)" : "none",
-                  }}
-                >
-                  ♥
-                </span>
-              ))}
+            <div
+              className="mt-0.5 font-mono text-[9px] font-bold tracking-[0.18em] text-rose-300/90"
+              style={{ textShadow: "0 0 6px rgba(244,63,94,0.7)" }}
+            >
+              ♥ ONE LIFE
             </div>
           </div>
 
@@ -1011,26 +1018,23 @@ export default function StremeSkateGame({
             </div>
           )}
 
-          {/* level progress meter (start → 🏁 finish), with zone segments */}
+          {/* zone meter — fills across the current biome, then loops to the
+              next one (endless). The current zone name rides above it. */}
           <div className="absolute bottom-1.5 left-3 right-3 pointer-events-none">
-            <div className="mb-0.5 flex items-center justify-center">
+            <div className="mb-0.5 flex items-center justify-between">
               <span
                 className="font-mono text-[10px] font-bold tracking-[0.2em]"
                 style={{ color: zone.accent, textShadow: `0 0 8px ${zone.accent}` }}
               >
                 {zone.name}
               </span>
+              <span className="font-mono text-[9px] font-semibold tracking-[0.16em] text-white/40">
+                NEXT: {ZONE_NAMES[(zone.index + 1) % ZONE_NAMES.length]}
+              </span>
             </div>
-            <div className="relative h-2 w-full overflow-hidden rounded-full bg-black/40 flex">
-              {ZONE_COLORS.map((c, i) => (
-                <div
-                  key={i}
-                  className="h-full flex-1"
-                  style={{ background: c, opacity: 0.22 }}
-                />
-              ))}
+            <div className="relative h-2 w-full overflow-hidden rounded-full bg-black/40">
               <div
-                className="absolute inset-y-0 left-0 transition-[width] duration-150"
+                className="absolute inset-y-0 left-0"
                 style={{
                   width: `${Math.min(progress * 100, 100)}%`,
                   background: zone.accent,
@@ -1043,9 +1047,6 @@ export default function StremeSkateGame({
                 style={{ left: `calc(${Math.min(progress * 100, 100)}% - 7px)` }}
               >
                 🛹
-              </div>
-              <div className="absolute top-1/2 right-0.5 -translate-y-1/2 text-[10px] leading-none">
-                🏁
               </div>
             </div>
           </div>
@@ -1243,14 +1244,8 @@ export default function StremeSkateGame({
           onPointerDown={(e) => e.stopPropagation()}
         >
           <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-6 shadow-2xl text-center">
-            <div
-              className={`text-sm font-bold uppercase tracking-widest ${
-                finishedRun.finished ? "text-success" : "opacity-60"
-              }`}
-            >
-              {finishedRun.finished
-                ? "🏁 Level complete!"
-                : `Out of lives · ${Math.round(progress * 100)}% there`}
+            <div className="text-sm font-bold uppercase tracking-widest opacity-60">
+              💥 Wipeout · {finishedRun.distance.toLocaleString()}m
             </div>
             <div className="mt-2 font-mono text-5xl font-bold text-primary">
               {finishedRun.score.toLocaleString()}

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -1,0 +1,1496 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import sdk from "@farcaster/miniapp-sdk";
+import confetti from "canvas-confetti";
+import { Trophy, Volume2, VolumeX, X } from "lucide-react";
+import { useAppFrameLogic } from "../../hooks/useAppFrameLogic";
+import { useUnifiedWallet } from "../../hooks/useUnifiedWallet";
+import {
+  SkateGameEngine,
+  CalloutKind,
+  ComboInfo,
+  GhostInput,
+  SfxType,
+  SkateResult,
+  SwipeDir,
+} from "./SkateGameEngine";
+import { buildSkateShareIntent } from "../../lib/skateShare";
+
+export interface SkateChallenge {
+  score: number;
+  by?: string;
+  rank?: number;
+}
+
+interface LeaderboardEntry {
+  fid: number;
+  username: string;
+  pfpUrl: string;
+  score: number;
+  combo: number;
+}
+
+interface LeaderboardData {
+  entries: LeaderboardEntry[];
+  player: { rank: number; best: number } | null;
+  total: number;
+}
+
+interface RankResult {
+  best: number;
+  rank: number;
+  total: number;
+  improved: boolean;
+}
+
+type Phase = "ready" | "playing" | "over";
+
+const BEST_KEY = "streme-skate-best";
+const MUTED_KEY = "streme-skate-muted";
+const GHOSTS_KEY = "streme-skate-ghosts";
+const WARPLET_KEY = "streme-skate-warplet";
+const LETTERS = ["S", "T", "R", "E", "M", "E"];
+const GHOST_TINTS = ["#fb7185", "#a78bfa", "#34d399", "#fbbf24", "#38bdf8"];
+
+interface WarpletItem {
+  tokenId: string;
+  name: string;
+  image: string;
+}
+
+/**
+ * Knock the (uniform, dark) background out of a Warplet NFT image so the
+ * creature rides transparently. Flood-fills from the corners over pixels close
+ * to the corner colour, so it won't punch holes inside the warplet. The source
+ * is same-origin (our proxy), so the canvas stays untainted.
+ */
+function removeWarpletBg(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const S = 128;
+        const c = document.createElement("canvas");
+        c.width = S;
+        c.height = S;
+        const ctx = c.getContext("2d", { willReadFrequently: true });
+        if (!ctx) return resolve(img);
+        ctx.drawImage(img, 0, 0, S, S);
+        const data = ctx.getImageData(0, 0, S, S);
+        const p = data.data;
+        const corners = [0, (S - 1) * 4, S * (S - 1) * 4, (S * S - 1) * 4];
+        let br = 0,
+          bg = 0,
+          bb = 0;
+        for (const o of corners) {
+          br += p[o];
+          bg += p[o + 1];
+          bb += p[o + 2];
+        }
+        br /= 4;
+        bg /= 4;
+        bb /= 4;
+        const TOL = 66 * 66;
+        const near = (o: number) => {
+          const dr = p[o] - br,
+            dg = p[o + 1] - bg,
+            db = p[o + 2] - bb;
+          return dr * dr + dg * dg + db * db < TOL;
+        };
+        const visited = new Uint8Array(S * S);
+        const stack: number[] = [];
+        const push = (x: number, y: number) => {
+          if (x < 0 || y < 0 || x >= S || y >= S) return;
+          const i = y * S + x;
+          if (visited[i]) return;
+          visited[i] = 1;
+          const o = i * 4;
+          if (near(o)) {
+            p[o + 3] = 0;
+            stack.push(x, y);
+          }
+        };
+        push(0, 0);
+        push(S - 1, 0);
+        push(0, S - 1);
+        push(S - 1, S - 1);
+        while (stack.length) {
+          const y = stack.pop() as number;
+          const x = stack.pop() as number;
+          push(x + 1, y);
+          push(x - 1, y);
+          push(x, y + 1);
+          push(x, y - 1);
+        }
+        ctx.putImageData(data, 0, 0);
+        const out = new Image();
+        out.onload = () => resolve(out);
+        out.onerror = () => resolve(img);
+        out.src = c.toDataURL();
+      } catch {
+        resolve(img);
+      }
+    };
+    img.onerror = reject;
+    img.src = url;
+  });
+}
+interface WarpletInfo {
+  eligible: boolean;
+  streme: number;
+  staked: number;
+  ownsWarplet: boolean;
+  warplets: WarpletItem[];
+}
+
+const ZONE_COLORS = ["#67e8f9", "#2dd4bf", "#fb923c", "#c084fc", "#fbbf24"];
+
+const CALLOUT_COLORS: Record<CalloutKind, string> = {
+  perfect: "#fde68a",
+  sick: "#34d399",
+  sloppy: "#f87171",
+  close: "#fb923c",
+  combo: "#67e8f9",
+  power: "#c4b5fd",
+  milestone: "#ffffff",
+};
+
+export default function StremeSkateGame({
+  challenge,
+}: {
+  challenge?: SkateChallenge | null;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const engineRef = useRef<SkateGameEngine | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const musicRef = useRef<HTMLAudioElement | null>(null);
+  const musicStartedRef = useRef(false);
+  const mutedRef = useRef(false);
+  const bestRef = useRef(0);
+  const bankTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const [phase, setPhase] = useState<Phase>("ready");
+  const [score, setScore] = useState(0);
+  const [combo, setCombo] = useState<ComboInfo | null>(null);
+  const [bank, setBank] = useState<number | null>(null);
+  const [distance, setDistance] = useState(0);
+  const [progress, setProgress] = useState(0);
+  const [zone, setZone] = useState<{ name: string; index: number; accent: string }>(
+    { name: "NEON DOWNTOWN", index: 0, accent: "#67e8f9" }
+  );
+  const [lives, setLives] = useState(3);
+  const [special, setSpecial] = useState(0);
+  const [flow, setFlow] = useState(false);
+  const [letters, setLetters] = useState<boolean[]>([
+    false, false, false, false, false, false,
+  ]);
+  const [toast, setToast] = useState<string | null>(null);
+  const [callouts, setCallouts] = useState<
+    { id: number; text: string; kind: CalloutKind }[]
+  >([]);
+  const [power, setPower] = useState<"magnet" | "rocket" | null>(null);
+  const calloutId = useRef(0);
+  const [best, setBest] = useState(0);
+  const [isNewBest, setIsNewBest] = useState(false);
+  const [muted, setMuted] = useState(false);
+  const [ghostsOn, setGhostsOn] = useState(true);
+  const [ghostCount, setGhostCount] = useState(0);
+  const ghostsRef = useRef<GhostInput[]>([]);
+  const ghostsOnRef = useRef(true);
+  const [warplet, setWarplet] = useState<WarpletInfo | null>(null);
+  const [selectedWarplet, setSelectedWarplet] = useState<string | null>(null);
+  const [showPicker, setShowPicker] = useState(false);
+  const warpletPfpRef = useRef<string | null>(null);
+  const [radMode, setRadMode] = useState(false);
+  const radModeRef = useRef(false);
+  const eggTapsRef = useRef(0);
+  const [challengeBeaten, setChallengeBeaten] = useState(false);
+  const [rankResult, setRankResult] = useState<RankResult | null>(null);
+  const [showBoard, setShowBoard] = useState(false);
+  const [board, setBoard] = useState<LeaderboardData | null>(null);
+  const [boardLoading, setBoardLoading] = useState(false);
+  const [finishedRun, setFinishedRun] = useState<SkateResult | null>(null);
+
+  const { isMiniAppView, isSDKLoaded, farcasterContext } = useAppFrameLogic();
+  const { address: walletAddress } = useUnifiedWallet();
+  const isMiniAppRef = useRef(false);
+  isMiniAppRef.current = isMiniAppView && isSDKLoaded;
+  const fcUserRef = useRef<{
+    fid: number;
+    username?: string;
+    pfpUrl?: string;
+  } | null>(null);
+  fcUserRef.current = farcasterContext?.user ?? null;
+  const challengeRef = useRef(challenge);
+  challengeRef.current = challenge;
+
+  // --------------------------------------------------------------- sound fx
+
+  const playTone = useCallback(
+    (
+      freq: number,
+      duration: number,
+      type: OscillatorType = "square",
+      volume = 0.06,
+      delay = 0,
+      slideTo?: number
+    ) => {
+      const ctx = audioCtxRef.current;
+      if (!ctx || mutedRef.current) return;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      const start = ctx.currentTime + delay;
+      osc.type = type;
+      osc.frequency.setValueAtTime(freq, start);
+      if (slideTo) osc.frequency.exponentialRampToValueAtTime(slideTo, start + duration);
+      gain.gain.setValueAtTime(volume, start);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(start);
+      osc.stop(start + duration);
+    },
+    []
+  );
+
+  const ensureAudio = useCallback(() => {
+    if (!audioCtxRef.current && typeof window !== "undefined") {
+      const Ctor =
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext?: typeof AudioContext })
+          .webkitAudioContext;
+      if (Ctor) audioCtxRef.current = new Ctor();
+    }
+    audioCtxRef.current?.resume().catch(() => {});
+  }, []);
+
+  const startMusic = useCallback(() => {
+    if (!musicRef.current) {
+      const audio = new Audio("/surf/theme.mp3");
+      audio.loop = true;
+      audio.volume = 0.32;
+      audio.preload = "auto";
+      musicRef.current = audio;
+    }
+    musicRef.current.muted = mutedRef.current;
+    musicRef.current
+      .play()
+      .then(() => {
+        musicStartedRef.current = true;
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const onVisibility = () => {
+      const music = musicRef.current;
+      if (!music || !musicStartedRef.current) return;
+      if (document.hidden) music.pause();
+      else music.play().catch(() => {});
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      musicRef.current?.pause();
+      if (musicRef.current) musicRef.current.src = "";
+      musicRef.current = null;
+    };
+  }, []);
+
+  const haptic = useCallback((kind: "light" | "success" | "error") => {
+    if (!isMiniAppRef.current) return;
+    try {
+      if (kind === "light") sdk.haptics.impactOccurred("light");
+      else if (kind === "success") sdk.haptics.notificationOccurred("success");
+      else sdk.haptics.notificationOccurred("error");
+    } catch {
+      // unsupported
+    }
+  }, []);
+
+  const handleSfx = useCallback(
+    (type: SfxType) => {
+      switch (type) {
+        case "jump":
+          playTone(320, 0.12, "square", 0.05, 0, 640);
+          haptic("light");
+          break;
+        case "trick":
+          playTone(660, 0.07, "square", 0.05);
+          playTone(990, 0.08, "square", 0.045, 0.05);
+          haptic("light");
+          break;
+        case "land":
+          playTone(440, 0.08, "triangle", 0.06);
+          playTone(660, 0.1, "triangle", 0.05, 0.05);
+          break;
+        case "grind":
+          playTone(120, 0.18, "sawtooth", 0.04, 0, 90);
+          haptic("light");
+          break;
+        case "perfect":
+          playTone(659, 0.07, "square", 0.07);
+          playTone(880, 0.07, "square", 0.07, 0.06);
+          playTone(1318, 0.16, "square", 0.07, 0.12);
+          haptic("success");
+          break;
+        case "power":
+          playTone(523, 0.08, "square", 0.06);
+          playTone(784, 0.08, "square", 0.06, 0.07);
+          playTone(1046, 0.1, "square", 0.06, 0.14);
+          playTone(1318, 0.16, "square", 0.06, 0.21);
+          haptic("success");
+          break;
+        case "crash":
+          playTone(200, 0.3, "sawtooth", 0.06, 0, 60);
+          playTone(90, 0.4, "square", 0.05, 0.1);
+          haptic("error");
+          break;
+        case "bubble":
+          playTone(880, 0.06, "square", 0.05);
+          playTone(1320, 0.08, "square", 0.04, 0.04);
+          break;
+        case "letter":
+          playTone(523, 0.08, "triangle", 0.07);
+          playTone(784, 0.08, "triangle", 0.07, 0.07);
+          playTone(1046, 0.14, "triangle", 0.07, 0.14);
+          haptic("success");
+          break;
+        case "flow":
+          playTone(440, 0.1, "square", 0.06);
+          playTone(587, 0.1, "square", 0.06, 0.08);
+          playTone(880, 0.18, "square", 0.06, 0.16);
+          haptic("success");
+          break;
+        case "milestone":
+          playTone(659, 0.1, "square", 0.06);
+          playTone(988, 0.18, "square", 0.06, 0.1);
+          break;
+      }
+    },
+    [playTone, haptic]
+  );
+
+  const showToast = useCallback((text: string, ms = 1600) => {
+    setToast(text);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToast(null), ms);
+  }, []);
+
+  const showCallout = useCallback((text: string, kind: CalloutKind) => {
+    const id = ++calloutId.current;
+    setCallouts((prev) => [...prev.slice(-3), { id, text, kind }]);
+    setTimeout(() => {
+      setCallouts((prev) => prev.filter((c) => c.id !== id));
+    }, 900);
+  }, []);
+
+  // ------------------------------------------------------------- callbacks
+
+  const handleBank = useCallback((amount: number) => {
+    if (amount <= 0) return;
+    setBank(amount);
+    if (bankTimerRef.current) clearTimeout(bankTimerRef.current);
+    bankTimerRef.current = setTimeout(() => setBank(null), 1100);
+  }, []);
+
+  const handleAllLetters = useCallback(() => {
+    showToast("🔥 S-T-R-E-M-E complete — FLOW STATE!", 2200);
+    confetti({
+      particleCount: 90,
+      spread: 75,
+      origin: { y: 0.6 },
+      colors: ["#6366f1", "#ec4899", "#2dd4bf", "#67e8f9", "#fde68a"],
+    });
+  }, [showToast]);
+
+  const handleGameOver = useCallback((result: SkateResult) => {
+    setFinishedRun(result);
+    setPhase("over");
+    setCombo(null);
+    const beatBest = result.score > 0 && result.score > bestRef.current;
+    setIsNewBest(beatBest);
+    if (beatBest) {
+      bestRef.current = result.score;
+      setBest(result.score);
+      try {
+        localStorage.setItem(BEST_KEY, String(result.score));
+      } catch {}
+    }
+    playTone(523, 0.12, "square", 0.06);
+    playTone(392, 0.18, "square", 0.06, 0.12);
+
+    setRankResult(null);
+    const user = fcUserRef.current;
+    if (isMiniAppRef.current && user && result.score > 0) {
+      // a held Warplet becomes your leaderboard PFP too
+      const pfpUrl = warpletPfpRef.current
+        ? `${window.location.origin}${warpletPfpRef.current}`
+        : user.pfpUrl ?? "";
+      sdk.quickAuth
+        .fetch("/api/skate/leaderboard", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            score: result.score,
+            combo: result.bestCombo,
+            username: user.username ?? "",
+            pfpUrl,
+          }),
+        })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((r: RankResult | null) => {
+          if (r) setRankResult(r);
+        })
+        .catch((e) => console.error("Leaderboard submit failed:", e));
+
+      // submit this run as a ghost for others to race
+      const samples = engineRef.current?.getRecording() ?? [];
+      if (samples.length >= 8) {
+        sdk.quickAuth
+          .fetch("/api/skate/ghosts", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              score: result.score,
+              username: user.username ?? "",
+              samples,
+            }),
+          })
+          .catch((e) => console.error("Ghost submit failed:", e));
+      }
+    }
+    // challenge check
+    const ch = challengeRef.current;
+    if (ch && result.score >= ch.score) setChallengeBeaten(true);
+  }, [playTone]);
+
+  // keep latest callbacks in refs for the stable engine wiring
+  const cbRef = useRef({
+    handleBank,
+    handleAllLetters,
+    handleGameOver,
+    handleSfx,
+    showToast,
+    showCallout,
+  });
+  cbRef.current = {
+    handleBank,
+    handleAllLetters,
+    handleGameOver,
+    handleSfx,
+    showToast,
+    showCallout,
+  };
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const engine = new SkateGameEngine(container, {
+      onStart: () => {
+        engineRef.current?.setGhosts(
+          ghostsOnRef.current ? ghostsRef.current : []
+        );
+        engineRef.current?.setRainbow(radModeRef.current);
+        setPhase("playing");
+        setScore(0);
+        setCombo(null);
+        setBank(null);
+        setDistance(0);
+        setProgress(0);
+        setLives(3);
+        setSpecial(0);
+        setFlow(false);
+        setLetters([false, false, false, false, false, false]);
+        setToast(null);
+        setCallouts([]);
+        setPower(null);
+        setChallengeBeaten(false);
+        setFinishedRun(null);
+      },
+      onScore: (s) => setScore(s),
+      onCombo: (c) => setCombo(c),
+      onBank: (a) => cbRef.current.handleBank(a),
+      onBail: (lost: number) => {
+        cbRef.current.showToast(
+          lost > 0
+            ? `💥 BAILED — lost ${lost.toLocaleString()}!`
+            : "💥 Wipeout!",
+          1100
+        );
+      },
+      onLetters: (l) => setLetters(l),
+      onAllLetters: () => cbRef.current.handleAllLetters(),
+      onFlow: (active) => setFlow(active),
+      onSpecial: (v) => setSpecial(v),
+      onDistance: (d) => setDistance(d),
+      onProgress: (p) => setProgress(p),
+      onZone: (name, index, accent) => setZone({ name, index, accent }),
+      onLives: (n) => setLives(n),
+      onCallout: (text, kind) => cbRef.current.showCallout(text, kind),
+      onPower: (kind) => setPower(kind),
+      onSfx: (t) => cbRef.current.handleSfx(t),
+      onGameOver: (r) => cbRef.current.handleGameOver(r),
+    });
+    engineRef.current = engine;
+
+    const observer = new ResizeObserver(() => {
+      engine.resize(container.clientWidth, container.clientHeight);
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      engine.dispose();
+      engineRef.current = null;
+    };
+  }, []);
+
+  // saved best + sound + ghost preference
+  useEffect(() => {
+    try {
+      const savedBest = Number(localStorage.getItem(BEST_KEY)) || 0;
+      bestRef.current = savedBest;
+      setBest(savedBest);
+      const savedMuted = localStorage.getItem(MUTED_KEY) === "true";
+      setMuted(savedMuted);
+      mutedRef.current = savedMuted;
+      const savedGhosts = localStorage.getItem(GHOSTS_KEY) !== "false"; // default ON
+      setGhostsOn(savedGhosts);
+      ghostsOnRef.current = savedGhosts;
+    } catch {}
+    return () => {
+      if (bankTimerRef.current) clearTimeout(bankTimerRef.current);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+
+  // Fetch ghost runs to race against (default on)
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const fid = fcUserRef.current?.fid;
+        const res = await fetch(
+          `/api/skate/ghosts?limit=4${fid ? `&fid=${fid}` : ""}`
+        );
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          ghosts: { username: string; samples: number[] }[];
+        };
+        if (cancelled) return;
+        ghostsRef.current = (data.ghosts || []).map((g, i) => ({
+          samples: g.samples,
+          color: GHOST_TINTS[i % GHOST_TINTS.length],
+          name: g.username ? `@${g.username}` : "ghost",
+        }));
+        setGhostCount(ghostsRef.current.length);
+      } catch {
+        // no ghosts available — solo run
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSDKLoaded]);
+
+  // Check Warplet eligibility for the connected wallet
+  useEffect(() => {
+    let cancelled = false;
+    if (!walletAddress) {
+      setWarplet(null);
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetch(`/api/skate/warplets?address=${walletAddress}`);
+        if (!res.ok) return;
+        const data = (await res.json()) as WarpletInfo;
+        if (cancelled) return;
+        setWarplet(data);
+        if (data.eligible && data.warplets.length > 0) {
+          const fid = fcUserRef.current?.fid;
+          const saved = (() => {
+            try {
+              return localStorage.getItem(WARPLET_KEY);
+            } catch {
+              return null;
+            }
+          })();
+          const pick =
+            data.warplets.find((w) => w.tokenId === saved)?.tokenId ||
+            data.warplets.find((w) => w.tokenId === String(fid))?.tokenId ||
+            data.warplets[0].tokenId;
+          setSelectedWarplet(pick);
+        }
+      } catch {
+        // ignore — default skater
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [walletAddress]);
+
+  // Load the selected Warplet image into the engine as the rider sprite
+  useEffect(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    if (!selectedWarplet || !warplet?.eligible) {
+      engine.setSkaterImage(null);
+      warpletPfpRef.current = null;
+      return;
+    }
+    const url = `/api/skate/warplet-image?token=${selectedWarplet}`;
+    warpletPfpRef.current = url;
+    let cancelled = false;
+    removeWarpletBg(url)
+      .then((img) => {
+        if (!cancelled) engineRef.current?.setSkaterImage(img);
+      })
+      .catch(() => {});
+    try {
+      localStorage.setItem(WARPLET_KEY, selectedWarplet);
+    } catch {}
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWarplet, warplet?.eligible]);
+
+  // --------------------------------------------------------------- input
+
+  // Touch model: hold anywhere = tuck (build speed / dive), release = let go
+  // (launch off a crest / float). A quick flick while airborne is a trick and
+  // does not end the hold.
+  const gestureRef = useRef<{ x: number; y: number; fired: boolean } | null>(
+    null
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      ensureAudio();
+      if (phase === "over") return;
+      if (phase === "ready") startMusic();
+      engineRef.current?.holdStart();
+      gestureRef.current = { x: e.clientX, y: e.clientY, fired: false };
+    },
+    [phase, ensureAudio, startMusic]
+  );
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    const g = gestureRef.current;
+    if (!g || g.fired) return;
+    const dx = e.clientX - g.x;
+    const dy = e.clientY - g.y;
+    if (Math.abs(dx) > 26 || Math.abs(dy) > 26) {
+      g.fired = true;
+      let dir: SwipeDir;
+      if (Math.abs(dx) > Math.abs(dy)) dir = dx > 0 ? "right" : "left";
+      else dir = dy > 0 ? "down" : "up";
+      engineRef.current?.swipe(dir);
+    }
+  }, []);
+
+  const handlePointerUp = useCallback(() => {
+    gestureRef.current = null;
+    engineRef.current?.holdEnd();
+  }, []);
+
+  // keyboard for desktop play / testing: Space = hold/tuck, arrows = tricks
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const engine = engineRef.current;
+      if (!engine) return;
+      if (e.key === " " || e.key === "ArrowDown" || e.key === "s") {
+        e.preventDefault();
+        if (e.repeat) return;
+        ensureAudio();
+        if (phase === "ready") startMusic();
+        engine.holdStart();
+      } else if (e.key === "ArrowUp" || e.key === "w") {
+        engine.swipe("up");
+      } else if (e.key === "ArrowLeft" || e.key === "a") {
+        engine.swipe("left");
+      } else if (e.key === "ArrowRight" || e.key === "d") {
+        engine.swipe("right");
+      }
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === " " || e.key === "ArrowDown" || e.key === "s") {
+        engineRef.current?.holdEnd();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+    };
+  }, [phase, ensureAudio, startMusic]);
+
+  const handleRestart = useCallback(() => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    setIsNewBest(false);
+    setChallengeBeaten(false);
+    startMusic();
+    engine.reset();
+  }, [startMusic]);
+
+  const openBoard = useCallback(async () => {
+    setShowBoard(true);
+    setBoardLoading(true);
+    try {
+      const fid = fcUserRef.current?.fid;
+      const res = await fetch(
+        `/api/skate/leaderboard${fid ? `?fid=${fid}` : ""}`
+      );
+      if (res.ok) setBoard((await res.json()) as LeaderboardData);
+    } catch (e) {
+      console.error("Leaderboard fetch failed:", e);
+    } finally {
+      setBoardLoading(false);
+    }
+  }, []);
+
+  const toggleMute = useCallback(() => {
+    setMuted((prev) => {
+      const next = !prev;
+      mutedRef.current = next;
+      if (musicRef.current) musicRef.current.muted = next;
+      try {
+        localStorage.setItem(MUTED_KEY, String(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  const toggleGhosts = useCallback(() => {
+    setGhostsOn((prev) => {
+      const next = !prev;
+      ghostsOnRef.current = next;
+      try {
+        localStorage.setItem(GHOSTS_KEY, String(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  // 🥚 secret: tap the warplet on the title screen 7× to unlock RAD MODE
+  const tapEgg = useCallback(() => {
+    eggTapsRef.current += 1;
+    if (eggTapsRef.current >= 7 && !radModeRef.current) {
+      radModeRef.current = true;
+      setRadMode(true);
+      engineRef.current?.setRainbow(true);
+      ensureAudio();
+      playTone(523, 0.1, "square", 0.06);
+      playTone(659, 0.1, "square", 0.06, 0.09);
+      playTone(784, 0.1, "square", 0.06, 0.18);
+      playTone(1046, 0.22, "square", 0.06, 0.27);
+      confetti({
+        particleCount: 140,
+        spread: 110,
+        origin: { y: 0.5 },
+        colors: ["#fde68a", "#ec4899", "#67e8f9", "#a855f7", "#2dd4bf"],
+      });
+      showToast("🥚 SECRET FOUND — RAD MODE unlocked! 🌈", 2800);
+    }
+  }, [ensureAudio, playTone, showToast]);
+
+  const handleShare = useCallback(async () => {
+    const username =
+      (isMiniAppView && farcasterContext?.user?.username) || undefined;
+    const runScore = finishedRun?.score ?? score;
+    const runCombo = finishedRun?.bestCombo ?? 0;
+    const { castText, shareUrl } = buildSkateShareIntent({
+      score: runScore,
+      combo: runCombo,
+      username,
+      rankResult,
+      challenge,
+      challengeBeaten,
+    });
+
+    if (isMiniAppView && isSDKLoaded) {
+      try {
+        await sdk.actions.composeCast({ text: castText, embeds: [shareUrl] });
+        return;
+      } catch (e) {
+        console.error("composeCast failed, falling back to web:", e);
+      }
+    }
+    window.open(
+      `https://farcaster.xyz/~/compose?text=${encodeURIComponent(
+        castText
+      )}&embeds[]=${encodeURIComponent(shareUrl)}`,
+      "_blank"
+    );
+  }, [
+    score,
+    finishedRun,
+    challenge,
+    challengeBeaten,
+    rankResult,
+    isMiniAppView,
+    isSDKLoaded,
+    farcasterContext,
+  ]);
+
+  // ----------------------------------------------------------------- UI
+
+  const challengeLabel = challenge
+    ? `${challenge.score.toLocaleString()}${
+        challenge.by ? ` · @${challenge.by}` : ""
+      }`
+    : null;
+
+  return (
+    <div
+      className="relative h-full w-full overflow-hidden select-none touch-none"
+      style={{
+        background:
+          "linear-gradient(180deg, #0c0626 0%, #221060 45%, #45179b 60%, #2b1854 100%)",
+        WebkitTapHighlightColor: "transparent",
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <style>{`
+        @keyframes skFloat { 0%,100%{transform:translateY(0) rotate(-8deg)} 50%{transform:translateY(-8px) rotate(-4deg)} }
+        @keyframes skBankPop { 0%{transform:translateY(8px) scale(0.7);opacity:0} 25%{transform:translateY(0) scale(1.1);opacity:1} 100%{transform:translateY(-26px) scale(1);opacity:0} }
+        @keyframes skPulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+        @keyframes skCallout { 0%{transform:scale(0.5) rotate(-6deg);opacity:0} 18%{transform:scale(1.25) rotate(-2deg);opacity:1} 70%{transform:scale(1) rotate(0deg);opacity:1} 100%{transform:scale(1) rotate(0deg);opacity:0} }
+        @keyframes skShine { 0%{background-position:0% 50%} 100%{background-position:200% 50%} }
+        @keyframes skGlow { 0%,100%{transform:scale(1);filter:brightness(1)} 50%{transform:scale(1.05);filter:brightness(1.15)} }
+        @keyframes skBob { 0%,100%{transform:translateY(0) rotate(-3deg)} 50%{transform:translateY(-10px) rotate(2deg)} }
+        @keyframes skRise { 0%{transform:translateY(14px);opacity:0} 100%{transform:translateY(0);opacity:1} }
+      `}</style>
+
+      {/* canvas mounts here */}
+      <div ref={containerRef} className="absolute inset-0" />
+
+      {/* flow-state glowing frame */}
+      {flow && (
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            boxShadow: "inset 0 0 60px 8px rgba(103,232,249,0.5)",
+            border: "2px solid rgba(253,230,138,0.6)",
+          }}
+        />
+      )}
+
+      {/* ---------- HUD ---------- */}
+      {phase === "playing" && (
+        <>
+          {/* score + distance */}
+          <div className="absolute top-3 left-0 right-0 flex flex-col items-center pointer-events-none">
+            <div
+              className="font-mono text-4xl font-extrabold text-white"
+              style={{ textShadow: "0 0 14px rgba(236,72,153,0.8)" }}
+            >
+              {score.toLocaleString()}
+            </div>
+            <div className="font-mono text-xs font-semibold text-cyan-300">
+              {distance.toLocaleString()}m
+            </div>
+            <div className="mt-0.5 flex gap-0.5">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <span
+                  key={i}
+                  className="text-xs leading-none"
+                  style={{
+                    color: i < lives ? "#fb7185" : "rgba(255,255,255,0.18)",
+                    textShadow: i < lives ? "0 0 6px rgba(244,63,94,0.8)" : "none",
+                  }}
+                >
+                  ♥
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* STREME letters + special meter (top-left) */}
+          <div className="absolute top-3 left-3 flex flex-col gap-1.5 pointer-events-none">
+            <div className="flex gap-0.5">
+              {LETTERS.map((ch, i) => (
+                <span
+                  key={i}
+                  className={`flex h-4 w-4 items-center justify-center rounded font-mono text-[9px] font-bold ${
+                    letters[i]
+                      ? "bg-cyan-400 text-[#0c0626]"
+                      : "bg-white/10 text-white/40"
+                  }`}
+                >
+                  {ch}
+                </span>
+              ))}
+            </div>
+            <div className="h-2 w-24 overflow-hidden rounded-full bg-white/10">
+              <div
+                className="h-full rounded-full transition-[width] duration-150"
+                style={{
+                  width: `${Math.round(special * 100)}%`,
+                  background: flow
+                    ? "linear-gradient(90deg,#fde68a,#ec4899,#67e8f9)"
+                    : "linear-gradient(90deg,#6366f1,#2dd4bf)",
+                }}
+              />
+            </div>
+            {flow && (
+              <span className="font-mono text-[10px] font-bold text-amber-300 animate-pulse">
+                ⚡ FLOW STATE ×2
+              </span>
+            )}
+          </div>
+
+          {/* live combo readout */}
+          {combo && (
+            <div className="absolute left-0 right-0 top-28 flex flex-col items-center pointer-events-none px-4 text-center">
+              <div
+                className="font-mono text-sm font-bold uppercase tracking-wide text-cyan-200"
+                style={{ textShadow: "0 0 8px rgba(45,212,191,0.8)" }}
+              >
+                {combo.tricks.join(" + ")}
+              </div>
+              <div className="mt-0.5 font-mono text-2xl font-extrabold text-white">
+                {combo.live.toLocaleString()}
+                <span className="ml-1 text-pink-400">×{combo.multiplier}</span>
+              </div>
+            </div>
+          )}
+
+          {/* banked points pop */}
+          {bank && (
+            <div className="absolute left-0 right-0 top-44 flex justify-center pointer-events-none">
+              <div
+                className="font-mono text-3xl font-extrabold text-emerald-300"
+                style={{
+                  textShadow: "0 0 14px rgba(16,185,129,0.8)",
+                  animation: "skBankPop 1.1s ease-out forwards",
+                }}
+              >
+                +{bank.toLocaleString()}
+              </div>
+            </div>
+          )}
+
+          {/* toast */}
+          {toast && (
+            <div className="absolute left-0 right-0 top-16 flex justify-center pointer-events-none px-4">
+              <div className="rounded-full bg-white/10 backdrop-blur-md px-4 py-1.5 border border-cyan-300/30">
+                <span className="text-sm font-semibold text-white">{toast}</span>
+              </div>
+            </div>
+          )}
+
+          {/* arcade callouts (PERFECT! · SICK! · CLOSE! · ROCKET! · 1,000m!) */}
+          {callouts.length > 0 && (
+            <div className="absolute left-0 right-0 top-1/3 flex flex-col items-center gap-1 pointer-events-none">
+              {callouts.map((c) => (
+                <div
+                  key={c.id}
+                  className="font-mono font-extrabold tracking-wider"
+                  style={{
+                    fontSize: c.kind === "perfect" ? 40 : 28,
+                    color: CALLOUT_COLORS[c.kind],
+                    textShadow: `0 0 16px ${CALLOUT_COLORS[c.kind]}`,
+                    animation: "skCallout 0.9s ease-out forwards",
+                  }}
+                >
+                  {c.text}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* level progress meter (start → 🏁 finish), with zone segments */}
+          <div className="absolute bottom-1.5 left-3 right-3 pointer-events-none">
+            <div className="mb-0.5 flex items-center justify-center">
+              <span
+                className="font-mono text-[10px] font-bold tracking-[0.2em]"
+                style={{ color: zone.accent, textShadow: `0 0 8px ${zone.accent}` }}
+              >
+                {zone.name}
+              </span>
+            </div>
+            <div className="relative h-2 w-full overflow-hidden rounded-full bg-black/40 flex">
+              {ZONE_COLORS.map((c, i) => (
+                <div
+                  key={i}
+                  className="h-full flex-1"
+                  style={{ background: c, opacity: 0.22 }}
+                />
+              ))}
+              <div
+                className="absolute inset-y-0 left-0 transition-[width] duration-150"
+                style={{
+                  width: `${Math.min(progress * 100, 100)}%`,
+                  background: zone.accent,
+                  opacity: 0.9,
+                  boxShadow: `0 0 8px ${zone.accent}`,
+                }}
+              />
+              <div
+                className="absolute top-1/2 -translate-y-1/2 text-[11px] leading-none"
+                style={{ left: `calc(${Math.min(progress * 100, 100)}% - 7px)` }}
+              >
+                🛹
+              </div>
+              <div className="absolute top-1/2 right-0.5 -translate-y-1/2 text-[10px] leading-none">
+                🏁
+              </div>
+            </div>
+          </div>
+
+          {/* active power-up chip */}
+          {power && (
+            <div
+              className="absolute bottom-9 right-3 rounded-full bg-white/10 backdrop-blur-md px-3 py-1.5 pointer-events-none border"
+              style={{ borderColor: power === "rocket" ? "#fde68a66" : "#67e8f966" }}
+            >
+              <span
+                className="text-xs font-bold animate-pulse"
+                style={{ color: power === "rocket" ? "#fde68a" : "#67e8f9" }}
+              >
+                {power === "rocket" ? "🚀 ROCKET" : "🧲 MAGNET"}
+              </span>
+            </div>
+          )}
+
+          {/* challenge chip */}
+          {challengeLabel && !challengeBeaten && (
+            <div className="absolute bottom-9 left-3 rounded-full bg-white/10 backdrop-blur-md px-3 py-1.5 pointer-events-none">
+              <span className="text-xs font-semibold text-white">
+                🎯 Beat {challengeLabel}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* sound + leaderboard buttons */}
+      <div className="absolute top-3 right-3 flex gap-2">
+        {phase !== "playing" && (
+          <button
+            className="btn btn-circle btn-sm border-0 bg-white/10 text-white hover:bg-white/20"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={openBoard}
+            aria-label="Leaderboard"
+          >
+            <Trophy size={16} />
+          </button>
+        )}
+        <button
+          className="btn btn-circle btn-sm border-0 bg-white/10 text-white hover:bg-white/20"
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={toggleMute}
+          aria-label={muted ? "Unmute sound" : "Mute sound"}
+        >
+          {muted ? <VolumeX size={16} /> : <Volume2 size={16} />}
+        </button>
+      </div>
+
+      {/* ---------- start screen (title menu) ---------- */}
+      {phase === "ready" && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center pointer-events-none">
+          {/* legibility scrim */}
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(78% 52% at 50% 42%, rgba(8,4,22,0.82) 0%, rgba(8,4,22,0.5) 58%, transparent 100%)",
+            }}
+          />
+
+          {/* tagline */}
+          <div
+            className="rounded-full border border-cyan-300/30 bg-white/5 px-3 py-1 text-[10px] font-bold tracking-[0.34em] text-cyan-200/90"
+            style={{ animation: "skRise 0.5s ease-out both" }}
+          >
+            ENDLESS NEON SKATER
+          </div>
+
+          {/* character on a spotlight — tap me 7× for a secret */}
+          <div
+            className="relative pointer-events-auto"
+            onPointerDown={(e) => e.stopPropagation()}
+            onPointerUp={(e) => e.stopPropagation()}
+            onClick={tapEgg}
+            role="button"
+            aria-label="Skater"
+          >
+            <div
+              className="absolute left-1/2 top-1/2 -z-10 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full"
+              style={{
+                background:
+                  "radial-gradient(circle, rgba(103,232,249,0.4) 0%, rgba(236,72,153,0.18) 45%, transparent 72%)",
+              }}
+            />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={
+                selectedWarplet
+                  ? `/api/skate/warplet-image?token=${selectedWarplet}`
+                  : "/surf/monster.png"
+              }
+              alt="Streme skater"
+              className="relative h-28 w-28 object-contain drop-shadow-[0_0_30px_rgba(103,232,249,0.7)]"
+              style={{
+                imageRendering: selectedWarplet ? "auto" : "pixelated",
+                animation: "skBob 2.8s ease-in-out infinite",
+              }}
+            />
+          </div>
+
+          {/* title */}
+          <div className="relative" style={{ animation: "skRise 0.55s ease-out both" }}>
+            <h1
+              className="text-5xl font-black italic leading-none tracking-tighter"
+              style={{
+                backgroundImage:
+                  "linear-gradient(90deg,#67e8f9,#ec4899,#fde68a,#67e8f9)",
+                backgroundSize: "200% auto",
+                WebkitBackgroundClip: "text",
+                backgroundClip: "text",
+                color: "transparent",
+                filter: "drop-shadow(0 0 18px rgba(103,232,249,0.45))",
+                animation: "skShine 3.2s linear infinite",
+              }}
+            >
+              STREME SKATE
+            </h1>
+            {radMode && (
+              <div className="mt-1 text-[11px] font-black tracking-[0.25em] text-amber-200">
+                🌈 RAD MODE
+              </div>
+            )}
+          </div>
+
+          {/* stat chips */}
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            {best > 0 && (
+              <div className="rounded-full border border-amber-300/25 bg-white/8 px-3 py-1 font-mono text-xs text-amber-200">
+                🏆 Best {best.toLocaleString()}
+              </div>
+            )}
+            {challengeLabel && (
+              <div className="rounded-full border border-cyan-300/40 bg-cyan-400/15 px-3 py-1 font-mono text-xs text-cyan-100">
+                🎯 Beat {challengeLabel}
+              </div>
+            )}
+          </div>
+
+          {/* PLAY (visual — tapping anywhere drops you in) */}
+          <div
+            className="mt-1 inline-flex items-center gap-2 rounded-full px-10 py-3 text-xl font-black text-[#0c0626]"
+            style={{
+              background: "linear-gradient(90deg,#67e8f9,#34d399,#fbbf24)",
+              boxShadow: "0 0 34px rgba(103,232,249,0.55)",
+              animation: "skGlow 1.5s ease-in-out infinite",
+            }}
+          >
+            ▶ PLAY
+          </div>
+
+          {/* control hints */}
+          <div className="flex flex-col items-center gap-0.5 text-[11px] text-indigo-200/70">
+            <span>Tap = jump · hold in the air to flip</span>
+            <span>
+              Release to land clean →{" "}
+              <span className="font-semibold text-amber-200">SPEED BOOST</span>
+            </span>
+          </div>
+
+          {/* option chips — interactive, must not start the run */}
+          <div
+            className="mt-0.5 flex items-center gap-2 pointer-events-auto"
+            onPointerDown={(e) => e.stopPropagation()}
+            onPointerUp={(e) => e.stopPropagation()}
+            onPointerMove={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={toggleGhosts}
+              className={`rounded-full border px-3.5 py-1.5 text-xs font-bold transition ${
+                ghostsOn
+                  ? "border-cyan-300/50 bg-cyan-400/20 text-cyan-100"
+                  : "border-white/15 bg-white/5 text-white/60"
+              }`}
+            >
+              👻 {ghostsOn ? `Ghosts${ghostCount ? ` ·${ghostCount}` : ""}` : "Solo"}
+            </button>
+            <button
+              onClick={() => setShowPicker(true)}
+              className="rounded-full border border-amber-300/40 bg-amber-300/10 px-3.5 py-1.5 text-xs font-bold text-amber-100"
+            >
+              {selectedWarplet ? "✨ Warplet" : "🛹 Skater"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- game over ---------- */}
+      {phase === "over" && finishedRun && (
+        <div
+          className="absolute inset-0 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-[2px] px-4 pb-8 sm:pb-4"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-6 shadow-2xl text-center">
+            <div
+              className={`text-sm font-bold uppercase tracking-widest ${
+                finishedRun.finished ? "text-success" : "opacity-60"
+              }`}
+            >
+              {finishedRun.finished
+                ? "🏁 Level complete!"
+                : `Out of lives · ${Math.round(progress * 100)}% there`}
+            </div>
+            <div className="mt-2 font-mono text-5xl font-bold text-primary">
+              {finishedRun.score.toLocaleString()}
+            </div>
+            <div className="mt-1 flex flex-wrap justify-center gap-x-3 gap-y-0.5 font-mono text-xs text-cyan-500 font-semibold">
+              <span>🛹 {finishedRun.distance.toLocaleString()}m</span>
+              <span>🏆 combo {finishedRun.bestCombo.toLocaleString()}</span>
+              <span>🫧 {finishedRun.bubbles.toLocaleString()}</span>
+            </div>
+            {rankResult && (
+              <button
+                className="mt-1 font-mono text-sm font-semibold text-primary underline-offset-2 hover:underline"
+                onClick={openBoard}
+              >
+                🏆 #{rankResult.rank} of {rankResult.total} skaters
+              </button>
+            )}
+            <div className="mt-2 text-sm opacity-70">
+              {challengeBeaten && challenge ? (
+                <span className="font-bold text-success">
+                  🏆 Challenge smashed
+                  {challenge.by ? ` — sorry @${challenge.by}` : ""}!
+                </span>
+              ) : isNewBest ? (
+                <span className="font-bold text-success">🏆 New best run!</span>
+              ) : (
+                <>Best run: {best.toLocaleString()}</>
+              )}
+            </div>
+            <div className="mt-5 flex flex-col gap-2">
+              <button className="btn btn-primary w-full" onClick={handleShare}>
+                Challenge your friends
+              </button>
+              <button className="btn btn-outline w-full" onClick={handleRestart}>
+                Drop in again
+              </button>
+              <button className="btn btn-ghost btn-sm w-full" onClick={openBoard}>
+                <Trophy size={14} /> Leaderboard
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- skater / Warplet picker ---------- */}
+      {showPicker && (
+        <div
+          className="absolute inset-0 z-20 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-5 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold">Choose your skater</h2>
+              <button
+                className="btn btn-circle btn-ghost btn-sm"
+                onClick={() => setShowPicker(false)}
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </div>
+
+            <p className="mt-1 text-xs opacity-60">
+              Hold a{" "}
+              <a
+                href="https://opensea.io/collection/the-warplets-farcaster"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                Warplet
+              </a>{" "}
+              + 10M $STREME (or staked) to skate as your own Warplet.
+            </p>
+
+            <div className="mt-3 flex flex-col gap-2">
+              {/* default skater */}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => {
+                    setSelectedWarplet(null);
+                    setShowPicker(false);
+                  }}
+                  className={`flex flex-col items-center gap-1 rounded-xl border-2 p-2 ${
+                    !selectedWarplet ? "border-primary" : "border-base-300"
+                  }`}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src="/surf/monster.png"
+                    alt="Warplet"
+                    className="h-12 w-12 object-contain"
+                    style={{ imageRendering: "pixelated" }}
+                  />
+                  <span className="text-[10px] font-semibold">Classic</span>
+                </button>
+
+                {warplet?.eligible &&
+                  warplet.warplets.map((w) => (
+                    <button
+                      key={w.tokenId}
+                      onClick={() => {
+                        setSelectedWarplet(w.tokenId);
+                        setShowPicker(false);
+                      }}
+                      className={`flex flex-col items-center gap-1 rounded-xl border-2 p-2 ${
+                        selectedWarplet === w.tokenId
+                          ? "border-amber-400"
+                          : "border-base-300"
+                      }`}
+                      title={w.name}
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={w.image}
+                        alt={w.name}
+                        className="h-12 w-12 rounded-md object-cover bg-base-300"
+                      />
+                      <span className="text-[10px] font-semibold">
+                        #{w.tokenId}
+                      </span>
+                    </button>
+                  ))}
+              </div>
+
+              {/* status / requirements */}
+              {!walletAddress ? (
+                <div className="rounded-lg bg-base-200 p-3 text-center text-xs opacity-70">
+                  Connect your wallet in Farcaster to skate as a Warplet.
+                </div>
+              ) : !warplet ? (
+                <div className="flex justify-center py-3">
+                  <span className="loading loading-spinner loading-sm" />
+                </div>
+              ) : !warplet.eligible ? (
+                <div className="rounded-lg bg-base-200 p-3 text-xs">
+                  <div className="mb-1 font-semibold opacity-70">
+                    To unlock Warplet skaters:
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span>{warplet.ownsWarplet ? "✅" : "⬜️"}</span>
+                    <span>Own a Warplet NFT</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span>
+                      {warplet.streme >= 10_000_000 || warplet.staked >= 10_000_000
+                        ? "✅"
+                        : "⬜️"}
+                    </span>
+                    <span>
+                      Hold 10M $STREME or staked (you:{" "}
+                      {Math.max(warplet.streme, warplet.staked).toLocaleString()})
+                    </span>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ---------- leaderboard overlay ---------- */}
+      {showBoard && (
+        <div
+          className="absolute inset-0 z-20 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-5 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-bold flex items-center gap-2">
+                <Trophy size={18} className="text-warning" /> Top Skaters
+              </h2>
+              <button
+                className="btn btn-circle btn-ghost btn-sm"
+                onClick={() => setShowBoard(false)}
+                aria-label="Close leaderboard"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="mt-3 max-h-80 overflow-y-auto">
+              {boardLoading ? (
+                <div className="flex justify-center py-8">
+                  <span className="loading loading-spinner loading-md" />
+                </div>
+              ) : board && board.entries.length > 0 ? (
+                <ul className="flex flex-col gap-1">
+                  {board.entries.map((entry, i) => {
+                    const isMe = fcUserRef.current?.fid === entry.fid;
+                    return (
+                      <li
+                        key={entry.fid}
+                        className={`flex items-center gap-3 rounded-lg px-2 py-1.5 ${
+                          isMe ? "bg-primary/10 ring-1 ring-primary" : ""
+                        }`}
+                      >
+                        <span className="w-6 text-right font-mono text-sm opacity-60">
+                          {i + 1}
+                        </span>
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={entry.pfpUrl || "/icon-transparent.png"}
+                          alt=""
+                          className="w-7 h-7 rounded-full object-cover bg-base-300"
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).src =
+                              "/icon-transparent.png";
+                          }}
+                        />
+                        <span className="flex-1 truncate text-sm font-medium">
+                          {entry.username
+                            ? `@${entry.username}`
+                            : `fid ${entry.fid}`}
+                        </span>
+                        <span className="font-mono text-sm font-semibold text-primary">
+                          {entry.score.toLocaleString()}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="py-8 text-center text-sm opacity-60">
+                  No skaters yet — be the first on the board!
+                </p>
+              )}
+            </div>
+            {board?.player && board.player.rank > 10 && (
+              <div className="mt-2 rounded-lg bg-primary/10 px-3 py-2 text-center font-mono text-sm">
+                You: #{board.player.rank} · {board.player.best.toLocaleString()}
+              </div>
+            )}
+            {!isMiniAppView && (
+              <p className="mt-3 text-center text-xs opacity-60">
+                Play inside Farcaster to claim a spot on the board
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -153,7 +153,7 @@ const ZONE_NAMES = [
 ];
 
 const START_TIME = 18; // mirrors engine START_TIME (initial clock display)
-const TIME_CAP = 26; // mirrors engine TIME_CAP (timer bar is scaled to this)
+const STREME_TOKEN = "0x3B3Cd21242BA44e9865B066e5EF5d1cC1030CC58";
 
 const CALLOUT_COLORS: Record<CalloutKind, string> = {
   perfect: "#fde68a",
@@ -843,6 +843,23 @@ export default function StremeSkateGame({
     }
   }, [ensureAudio, playTone, showToast]);
 
+  // send a user who's short on $STREME to buy it. In the Farcaster mini-app
+  // this opens the native swap sheet (no leaving the game); on the web we fall
+  // back to the canonical token page where the full buy UI lives.
+  const handleBuyStreme = useCallback(async () => {
+    if (isMiniAppView && isSDKLoaded) {
+      try {
+        await sdk.actions.swapToken({
+          buyToken: `eip155:8453/erc20:${STREME_TOKEN}`,
+        });
+        return;
+      } catch (e) {
+        console.error("swapToken failed, falling back to token page:", e);
+      }
+    }
+    window.open(`/token/${STREME_TOKEN}`, "_blank");
+  }, [isMiniAppView, isSDKLoaded]);
+
   const handleShare = useCallback(async () => {
     const username =
       (isMiniAppView && farcasterContext?.user?.username) || undefined;
@@ -949,27 +966,19 @@ export default function StremeSkateGame({
             >
               ♥ ONE LIFE
             </div>
-            {/* countdown clock — drains in real time, recharges on great plays */}
+            {/* the sun (in-canvas) IS the clock; this is just a compact readout
+                that flashes red as it runs out, plus the +Xs recharge pop */}
             {(() => {
               const low = timeLeft <= 4;
               const mid = timeLeft <= 7;
-              const col = low ? "#f87171" : mid ? "#fbbf24" : "#34d399";
-              const pct = Math.max(0, Math.min(100, (timeLeft / TIME_CAP) * 100));
+              const col = low ? "#f87171" : mid ? "#fbbf24" : "#fcd34d";
               return (
-                <div className="mt-1 flex flex-col items-center">
-                  <div className="relative h-2.5 w-40 overflow-hidden rounded-full border border-white/10 bg-black/45">
-                    <div
-                      className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-100 ${
-                        low ? "animate-pulse" : ""
-                      }`}
-                      style={{ width: `${pct}%`, background: col, boxShadow: `0 0 8px ${col}` }}
-                    />
-                  </div>
+                <div className="mt-0.5 flex flex-col items-center">
                   <div
-                    className={`mt-0.5 font-mono text-xs font-bold ${low ? "animate-pulse" : ""}`}
+                    className={`font-mono text-xs font-bold ${low ? "animate-pulse" : ""}`}
                     style={{ color: col, textShadow: `0 0 8px ${col}` }}
                   >
-                    ⏱ {timeLeft.toFixed(1)}s
+                    ☀ {timeLeft.toFixed(1)}s
                   </div>
                   {timeBonus && (
                     <div
@@ -1465,6 +1474,14 @@ export default function StremeSkateGame({
                       {Math.max(warplet.streme, warplet.staked).toLocaleString()})
                     </span>
                   </div>
+                  {warplet.streme < 10_000_000 && warplet.staked < 10_000_000 && (
+                    <button
+                      onClick={handleBuyStreme}
+                      className="btn btn-primary btn-sm mt-3 w-full"
+                    >
+                      💰 Buy $STREME
+                    </button>
+                  )}
                 </div>
               ) : null}
             </div>

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -152,6 +152,9 @@ const ZONE_NAMES = [
   "OVERDRIVE",
 ];
 
+const START_TIME = 18; // mirrors engine START_TIME (initial clock display)
+const TIME_CAP = 26; // mirrors engine TIME_CAP (timer bar is scaled to this)
+
 const CALLOUT_COLORS: Record<CalloutKind, string> = {
   perfect: "#fde68a",
   sick: "#34d399",
@@ -187,6 +190,9 @@ export default function StremeSkateGame({
     { name: "NEON DOWNTOWN", index: 0, accent: "#67e8f9" }
   );
   const [special, setSpecial] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(START_TIME);
+  const [timeBonus, setTimeBonus] = useState<{ id: number; amount: number } | null>(null);
+  const timeBonusId = useRef(0);
   const [flow, setFlow] = useState(false);
   const [letters, setLetters] = useState<boolean[]>([
     false, false, false, false, false, false,
@@ -387,6 +393,21 @@ export default function StremeSkateGame({
     [playTone]
   );
 
+  // a great play recharged the clock — pop "+X.Xs" and chirp a reward chime
+  const handleTimeBonus = useCallback(
+    (amount: number) => {
+      const id = ++timeBonusId.current;
+      setTimeBonus({ id, amount });
+      playTone(720, 0.05, "sine", 0.045);
+      playTone(1080, 0.08, "sine", 0.04, 0.05);
+      setTimeout(
+        () => setTimeBonus((prev) => (prev && prev.id === id ? null : prev)),
+        850
+      );
+    },
+    [playTone]
+  );
+
   const showToast = useCallback((text: string, ms = 1600) => {
     setToast(text);
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
@@ -488,6 +509,7 @@ export default function StremeSkateGame({
     handleGameOver,
     handleSfx,
     handleGrindTick,
+    handleTimeBonus,
     showToast,
     showCallout,
   });
@@ -497,6 +519,7 @@ export default function StremeSkateGame({
     handleGameOver,
     handleSfx,
     handleGrindTick,
+    handleTimeBonus,
     showToast,
     showCallout,
   };
@@ -518,6 +541,8 @@ export default function StremeSkateGame({
         setDistance(0);
         setProgress(0);
         setSpecial(0);
+        setTimeLeft(START_TIME);
+        setTimeBonus(null);
         setFlow(false);
         setLetters([false, false, false, false, false, false]);
         setToast(null);
@@ -545,6 +570,8 @@ export default function StremeSkateGame({
       onProgress: (p) => setProgress(p),
       onZone: (name, index, accent) => setZone({ name, index, accent }),
       onGrindTick: (lvl) => cbRef.current.handleGrindTick(lvl),
+      onTime: (s) => setTimeLeft(s),
+      onTimeBonus: (a) => cbRef.current.handleTimeBonus(a),
       onCallout: (text, kind) => cbRef.current.showCallout(text, kind),
       onPower: (kind) => setPower(kind),
       onSfx: (t) => cbRef.current.handleSfx(t),
@@ -922,6 +949,43 @@ export default function StremeSkateGame({
             >
               ♥ ONE LIFE
             </div>
+            {/* countdown clock — drains in real time, recharges on great plays */}
+            {(() => {
+              const low = timeLeft <= 4;
+              const mid = timeLeft <= 7;
+              const col = low ? "#f87171" : mid ? "#fbbf24" : "#34d399";
+              const pct = Math.max(0, Math.min(100, (timeLeft / TIME_CAP) * 100));
+              return (
+                <div className="mt-1 flex flex-col items-center">
+                  <div className="relative h-2.5 w-40 overflow-hidden rounded-full border border-white/10 bg-black/45">
+                    <div
+                      className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-100 ${
+                        low ? "animate-pulse" : ""
+                      }`}
+                      style={{ width: `${pct}%`, background: col, boxShadow: `0 0 8px ${col}` }}
+                    />
+                  </div>
+                  <div
+                    className={`mt-0.5 font-mono text-xs font-bold ${low ? "animate-pulse" : ""}`}
+                    style={{ color: col, textShadow: `0 0 8px ${col}` }}
+                  >
+                    ⏱ {timeLeft.toFixed(1)}s
+                  </div>
+                  {timeBonus && (
+                    <div
+                      key={timeBonus.id}
+                      className="font-mono text-sm font-extrabold text-emerald-300"
+                      style={{
+                        textShadow: "0 0 10px rgba(16,185,129,0.85)",
+                        animation: "skBankPop 0.85s ease-out forwards",
+                      }}
+                    >
+                      +{timeBonus.amount.toFixed(1)}s
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
           </div>
 
           {/* STREME letters + special meter (top-left) */}
@@ -1245,7 +1309,8 @@ export default function StremeSkateGame({
         >
           <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-6 shadow-2xl text-center">
             <div className="text-sm font-bold uppercase tracking-widest opacity-60">
-              💥 Wipeout · {finishedRun.distance.toLocaleString()}m
+              {finishedRun.timedOut ? "⏱ Time up" : "💥 Wipeout"} ·{" "}
+              {finishedRun.distance.toLocaleString()}m
             </div>
             <div className="mt-2 font-mono text-5xl font-bold text-primary">
               {finishedRun.score.toLocaleString()}

--- a/src/lib/skateGhosts.ts
+++ b/src/lib/skateGhosts.ts
@@ -1,0 +1,87 @@
+import { Redis } from "@upstash/redis";
+
+export interface GhostRecord {
+  fid: number;
+  username: string;
+  score: number;
+  samples: number[]; // flat [px,py] pairs, sampled every 0.15s by the engine
+}
+
+const useRedis = process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN;
+const redis = useRedis
+  ? new Redis({
+      url: process.env.KV_REST_API_URL!,
+      token: process.env.KV_REST_API_TOKEN!,
+    })
+  : null;
+
+const ENV_SUFFIX = process.env.NODE_ENV === "production" ? "" : ":dev";
+const BOARD_KEY = `streme-skate:ghosts${ENV_SUFFIX}`; // sorted set fid → score
+const ghostKey = (fid: number) => `streme-skate:ghost:${fid}${ENV_SUFFIX}`;
+const KEEP = 80; // cap how many ghost recordings we retain
+const MAX_SAMPLES = 1400; // ~105s of run at 0.15s sampling
+
+const local = new Map<number, GhostRecord>();
+
+function sanitize(samples: number[]): number[] {
+  return samples
+    .slice(0, MAX_SAMPLES)
+    .map((n) => (Number.isFinite(n) ? Math.round(n) : 0));
+}
+
+export async function saveGhost(g: GhostRecord): Promise<void> {
+  const rec: GhostRecord = { ...g, samples: sanitize(g.samples) };
+  if (rec.samples.length < 8) return; // too short to be a useful ghost
+
+  if (redis) {
+    const current = await redis.zscore(BOARD_KEY, String(rec.fid));
+    if (current === null || rec.score > Number(current)) {
+      await redis.zadd(BOARD_KEY, { score: rec.score, member: String(rec.fid) });
+      await redis.set(ghostKey(rec.fid), JSON.stringify(rec));
+      // trim to the best KEEP recordings
+      const extra = await redis.zrange<string[]>(BOARD_KEY, 0, -KEEP - 1);
+      if (extra.length) {
+        await redis.zrem(BOARD_KEY, ...extra);
+        await Promise.all(extra.map((fid) => redis.del(ghostKey(Number(fid)))));
+      }
+    }
+    return;
+  }
+
+  const existing = local.get(rec.fid);
+  if (!existing || rec.score > existing.score) local.set(rec.fid, rec);
+}
+
+export async function getGhosts(
+  limit = 4,
+  excludeFid?: number
+): Promise<GhostRecord[]> {
+  if (redis) {
+    // pull a pool of the top runs, then take a varied slice
+    const members = await redis.zrange<string[]>(BOARD_KEY, 0, limit + 6, {
+      rev: true,
+    });
+    const fids = members
+      .map(Number)
+      .filter((fid) => fid !== excludeFid)
+      .slice(0, limit);
+    if (fids.length === 0) return [];
+    const rows = await Promise.all(fids.map((fid) => redis.get(ghostKey(fid))));
+    const out: GhostRecord[] = [];
+    for (const row of rows) {
+      if (!row) continue;
+      try {
+        const rec = typeof row === "string" ? JSON.parse(row) : row;
+        if (rec && Array.isArray(rec.samples)) out.push(rec as GhostRecord);
+      } catch {
+        // skip malformed
+      }
+    }
+    return out;
+  }
+
+  return [...local.values()]
+    .filter((g) => g.fid !== excludeFid)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/src/lib/skateLeaderboard.ts
+++ b/src/lib/skateLeaderboard.ts
@@ -1,0 +1,145 @@
+import { Redis } from "@upstash/redis";
+
+export interface SkateEntry {
+  fid: number;
+  username: string;
+  pfpUrl: string;
+  score: number;
+  combo: number; // best single combo of the run
+  updatedAt: number;
+}
+
+export interface SkateSubmitResult {
+  best: number;
+  rank: number; // 1-based
+  total: number;
+  improved: boolean;
+}
+
+// Use Redis if KV env vars are present, otherwise an in-memory fallback
+// (mirrors src/lib/surfLeaderboard.ts). Dev writes are namespaced away from
+// production.
+const useRedis = process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN;
+const redis = useRedis
+  ? new Redis({
+      url: process.env.KV_REST_API_URL!,
+      token: process.env.KV_REST_API_TOKEN!,
+    })
+  : null;
+
+const ENV_SUFFIX = process.env.NODE_ENV === "production" ? "" : ":dev";
+const BOARD_KEY = `streme-skate:leaderboard${ENV_SUFFIX}`;
+const playerKey = (fid: number) => `streme-skate:player:${fid}${ENV_SUFFIX}`;
+
+// In-memory fallback
+const localBoard = new Map<number, SkateEntry>();
+
+function localRankOf(fid: number): { rank: number; total: number } {
+  const sorted = [...localBoard.values()].sort((a, b) => b.score - a.score);
+  return {
+    rank: sorted.findIndex((e) => e.fid === fid) + 1,
+    total: sorted.length,
+  };
+}
+
+export async function submitSkateScore(
+  entry: Omit<SkateEntry, "updatedAt">
+): Promise<SkateSubmitResult> {
+  const now = Date.now();
+  if (redis) {
+    const current = await redis.zscore(BOARD_KEY, String(entry.fid));
+    const improved = current === null || entry.score > Number(current);
+    if (improved) {
+      await redis.zadd(BOARD_KEY, {
+        score: entry.score,
+        member: String(entry.fid),
+      });
+      await redis.hset(playerKey(entry.fid), { ...entry, updatedAt: now });
+    } else {
+      // Keep profile fresh even when the score doesn't improve
+      await redis.hset(playerKey(entry.fid), {
+        username: entry.username,
+        pfpUrl: entry.pfpUrl,
+      });
+    }
+    const [rank, total] = await Promise.all([
+      redis.zrevrank(BOARD_KEY, String(entry.fid)),
+      redis.zcard(BOARD_KEY),
+    ]);
+    return {
+      best: improved ? entry.score : Number(current),
+      rank: (rank ?? 0) + 1,
+      total,
+      improved,
+    };
+  }
+
+  const existing = localBoard.get(entry.fid);
+  const improved = !existing || entry.score > existing.score;
+  if (improved) {
+    localBoard.set(entry.fid, { ...entry, updatedAt: now });
+  }
+  const { rank, total } = localRankOf(entry.fid);
+  return {
+    best: improved ? entry.score : existing!.score,
+    rank,
+    total,
+    improved,
+  };
+}
+
+export async function getSkateLeaderboard(
+  limit = 10,
+  fid?: number
+): Promise<{
+  entries: SkateEntry[];
+  player: { rank: number; best: number } | null;
+  total: number;
+}> {
+  if (redis) {
+    const members = await redis.zrange<string[]>(BOARD_KEY, 0, limit - 1, {
+      rev: true,
+    });
+    const entries: SkateEntry[] = [];
+    if (members.length > 0) {
+      const pipeline = redis.pipeline();
+      for (const member of members) {
+        pipeline.hgetall(playerKey(Number(member)));
+      }
+      const rows = await pipeline.exec<(Record<string, unknown> | null)[]>();
+      rows.forEach((row, i) => {
+        if (row) {
+          entries.push({
+            fid: Number(members[i]),
+            username: String(row.username ?? ""),
+            pfpUrl: String(row.pfpUrl ?? ""),
+            score: Number(row.score ?? 0),
+            combo: Number(row.combo ?? 0),
+            updatedAt: Number(row.updatedAt ?? 0),
+          });
+        }
+      });
+    }
+    const total = await redis.zcard(BOARD_KEY);
+    let player: { rank: number; best: number } | null = null;
+    if (fid) {
+      const [rank, best] = await Promise.all([
+        redis.zrevrank(BOARD_KEY, String(fid)),
+        redis.zscore(BOARD_KEY, String(fid)),
+      ]);
+      if (rank !== null && best !== null) {
+        player = { rank: rank + 1, best: Number(best) };
+      }
+    }
+    return { entries, player, total };
+  }
+
+  const sorted = [...localBoard.values()].sort((a, b) => b.score - a.score);
+  const entries = sorted.slice(0, limit);
+  let player: { rank: number; best: number } | null = null;
+  if (fid) {
+    const idx = sorted.findIndex((e) => e.fid === fid);
+    if (idx >= 0) player = { rank: idx + 1, best: sorted[idx].score };
+  }
+  return { entries, player, total: sorted.length };
+}

--- a/src/lib/skateShare.ts
+++ b/src/lib/skateShare.ts
@@ -1,0 +1,99 @@
+export interface SkateChallenge {
+  score: number;
+  by?: string;
+  rank?: number;
+}
+
+export interface SkateRankResult {
+  best: number;
+  rank: number;
+  total: number;
+  improved: boolean;
+}
+
+export const SKATE_SHARE_URL = "https://streme.fun/skate";
+export const SKATE_DISPLAY_URL = "streme.fun/skate";
+
+interface BuildSkateShareInput {
+  score: number;
+  combo: number;
+  username?: string;
+  rankResult?: SkateRankResult | null;
+  challenge?: SkateChallenge | null;
+  challengeBeaten?: boolean;
+  baseShareUrl?: string;
+}
+
+interface SkateShareIntent {
+  shareUrl: string;
+  castText: string;
+}
+
+const USERNAME_RE = /^[a-z0-9_.-]{1,32}$/i;
+const MAX_SHARE_SCORE = 100_000_000;
+
+function normalizedScore(score: number): number {
+  if (!Number.isFinite(score)) return 0;
+  return Math.min(Math.max(Math.floor(score), 0), MAX_SHARE_SCORE);
+}
+
+function normalizedCombo(combo: number): number {
+  if (!Number.isFinite(combo)) return 0;
+  return Math.max(Math.floor(combo), 0);
+}
+
+function normalizedUsername(username?: string): string | undefined {
+  return username && USERNAME_RE.test(username) ? username : undefined;
+}
+
+function rankAppliesToScore(
+  rankResult: SkateRankResult | null | undefined,
+  score: number
+): rankResult is SkateRankResult {
+  return Boolean(rankResult && normalizedScore(rankResult.best) === score);
+}
+
+export function buildSkateShareIntent({
+  score,
+  combo,
+  username,
+  rankResult,
+  challenge,
+  challengeBeaten = false,
+  baseShareUrl = SKATE_SHARE_URL,
+}: BuildSkateShareInput): SkateShareIntent {
+  const runScore = normalizedScore(score);
+  const comboCount = normalizedCombo(combo);
+  const by = normalizedUsername(username);
+
+  let cardScore = runScore;
+  let rankForCard: number | undefined;
+  let opener: string;
+
+  if (challengeBeaten && challenge) {
+    opener = `I smashed ${
+      challenge.by ? `@${challenge.by}'s` : "the"
+    } ${challenge.score.toLocaleString()} challenge — scored ${runScore.toLocaleString()} in Streme Skate 🛹⚡`;
+
+    if (rankAppliesToScore(rankResult, runScore)) {
+      rankForCard = rankResult.rank;
+      opener += `\n\nNow #${rankResult.rank} on the leaderboard 🏆`;
+    }
+  } else if (rankResult) {
+    cardScore = normalizedScore(rankResult.best);
+    rankForCard = rankResult.rank;
+    opener = `I'm #${rankResult.rank} of ${rankResult.total} on the Streme Skate leaderboard with ${cardScore.toLocaleString()} points 🛹⚡`;
+  } else {
+    opener = `I scored ${runScore.toLocaleString()} on a ${comboCount.toLocaleString()}-point combo in Streme Skate 🛹⚡`;
+  }
+
+  const params = new URLSearchParams({ s: String(cardScore) });
+  if (by) params.set("by", by);
+  if (rankForCard) params.set("r", String(rankForCard));
+
+  const shareUrl = `${baseShareUrl}?${params.toString()}`;
+  return {
+    shareUrl,
+    castText: `${opener}\n\nThink you can beat my line?\n\n${shareUrl}`,
+  };
+}

--- a/src/lib/warplets.ts
+++ b/src/lib/warplets.ts
@@ -1,0 +1,183 @@
+import { publicClient } from "./viemClient";
+
+// The Warplets (Farcaster) — opensea.io/collection/the-warplets-farcaster
+export const WARPLET_NFT = "0x699727f9e01a822efdcf7333073f0461e5914b4e" as const;
+const STREME = "0x3b3cd21242ba44e9865b066e5ef5d1cc1030cc58" as const;
+const STAKE_POOL = "0xa040a8564c433970d7919c441104b1d25b9eaa1c" as const;
+const STAKE_FUNDER = "0xceaCfbB5A17b6914051D12D8c91d3461382d503b" as const;
+const MIN_HOLD = 10_000_000n * 10n ** 18n; // 10,000,000 STREME (18 decimals)
+const MAX_WARPLETS = 24;
+
+const erc20Abi = [
+  {
+    inputs: [{ name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+const enumerableAbi = [
+  {
+    inputs: [{ name: "owner", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "index", type: "uint256" },
+    ],
+    name: "tokenOfOwnerByIndex",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "tokenId", type: "uint256" }],
+    name: "tokenURI",
+    outputs: [{ name: "", type: "string" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
+export interface WarpletItem {
+  tokenId: string;
+  name: string;
+  image: string; // same-origin proxy URL, canvas-safe
+}
+
+export interface WarpletEligibility {
+  eligible: boolean;
+  streme: number; // formatted (whole STREME)
+  staked: number;
+  ownsWarplet: boolean;
+  warplets: WarpletItem[];
+}
+
+/** ipfs://CID (and /ipfs/CID) → a public gateway URL. */
+export function resolveIpfs(uri: string): string {
+  if (!uri) return "";
+  if (uri.startsWith("ipfs://")) {
+    return `https://ipfs.io/ipfs/${uri.slice(7).replace(/^ipfs\//, "")}`;
+  }
+  return uri;
+}
+
+/** Decode an on-chain `data:application/json;base64,...` tokenURI. */
+function decodeDataUri(uri: string): { name?: string; image?: string } | null {
+  const m = uri.match(/^data:application\/json;base64,(.*)$/);
+  if (!m) return null;
+  try {
+    const json = Buffer.from(m[1], "base64").toString("utf-8");
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+/** Read & decode a single Warplet's metadata (used by the image proxy). */
+export async function getWarpletImageUri(tokenId: bigint): Promise<string | null> {
+  try {
+    const uri = (await publicClient.readContract({
+      address: WARPLET_NFT,
+      abi: enumerableAbi,
+      functionName: "tokenURI",
+      args: [tokenId],
+    })) as string;
+    const meta = decodeDataUri(uri);
+    return meta?.image ? resolveIpfs(meta.image) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getWarpletEligibility(
+  address: string
+): Promise<WarpletEligibility> {
+  const addr = address as `0x${string}`;
+  const empty: WarpletEligibility = {
+    eligible: false,
+    streme: 0,
+    staked: 0,
+    ownsWarplet: false,
+    warplets: [],
+  };
+
+  let stremeBal = 0n;
+  let stakedBal = 0n;
+  let nftBal = 0n;
+  try {
+    const [streme, pool, funder, nft] = await publicClient.multicall({
+      contracts: [
+        { address: STREME, abi: erc20Abi, functionName: "balanceOf", args: [addr] },
+        { address: STAKE_POOL, abi: erc20Abi, functionName: "balanceOf", args: [addr] },
+        { address: STAKE_FUNDER, abi: erc20Abi, functionName: "balanceOf", args: [addr] },
+        { address: WARPLET_NFT, abi: enumerableAbi, functionName: "balanceOf", args: [addr] },
+      ],
+    });
+    stremeBal = streme.status === "success" ? (streme.result as bigint) : 0n;
+    const poolBal = pool.status === "success" ? (pool.result as bigint) : 0n;
+    const funderBal = funder.status === "success" ? (funder.result as bigint) : 0n;
+    stakedBal = poolBal > funderBal ? poolBal : funderBal;
+    nftBal = nft.status === "success" ? (nft.result as bigint) : 0n;
+  } catch (e) {
+    console.error("warplet eligibility multicall failed:", e);
+    return empty;
+  }
+
+  const hasHold = stremeBal >= MIN_HOLD || stakedBal >= MIN_HOLD;
+  const ownsWarplet = nftBal > 0n;
+  const result: WarpletEligibility = {
+    eligible: hasHold && ownsWarplet,
+    streme: Number(stremeBal / 10n ** 18n),
+    staked: Number(stakedBal / 10n ** 18n),
+    ownsWarplet,
+    warplets: [],
+  };
+
+  // Only enumerate the warplets if they actually qualify
+  if (!result.eligible) return result;
+
+  try {
+    const count = Math.min(Number(nftBal), MAX_WARPLETS);
+    const idCalls = Array.from({ length: count }, (_, i) => ({
+      address: WARPLET_NFT,
+      abi: enumerableAbi,
+      functionName: "tokenOfOwnerByIndex" as const,
+      args: [addr, BigInt(i)] as const,
+    }));
+    const ids = await publicClient.multicall({ contracts: idCalls });
+    const tokenIds = ids
+      .filter((r) => r.status === "success")
+      .map((r) => r.result as bigint);
+
+    const uriCalls = tokenIds.map((id) => ({
+      address: WARPLET_NFT,
+      abi: enumerableAbi,
+      functionName: "tokenURI" as const,
+      args: [id] as const,
+    }));
+    const uris = await publicClient.multicall({ contracts: uriCalls });
+    result.warplets = tokenIds.map((id, i) => {
+      const uriRes = uris[i];
+      const meta =
+        uriRes && uriRes.status === "success"
+          ? decodeDataUri(uriRes.result as string)
+          : null;
+      return {
+        tokenId: id.toString(),
+        name: meta?.name || `Warplet #${id.toString()}`,
+        image: `/api/skate/warplet-image?token=${id.toString()}`,
+      };
+    });
+  } catch (e) {
+    console.error("warplet enumeration failed:", e);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 🛹 Streme Skate

A GBA/Tony-Hawk-style neon **endless** skater at **`/skate`** — the second arcade mini-app after Surf. One-button, mobile-first, one life, beat-the-clock, built for sharing.

### Gameplay
- **One-button feel** (Canabalt/OlliOlli/THPS): tap = ollie, **hold in the air = backflip**, **release to stomp** the landing → graded **PERFECT / SICK / SLOPPY** with a speed-boost reward for clean landings.
- **The sun is your clock** (Tiny Wings): a run timer drains in real time and **recharges when you pull off something great** — clean landings, near-misses, perfect grind exits, loops, letters, power-ups. The background **sun rides the clock** — high near noon when time is full, sinking below the horizon as it runs out, lifting back up on a recharge. Run it out and the run ends, so you must keep skating *well*, not just survive.
- **Auto-launch ramps** (big & small), grind **rails**, **gaps** with near-miss **CLOSE!** bonuses, **magnet/turbo** power-ups, screen shake + hitstop, speed lines, arcade callouts.
- **Turbo is pure speed, not invincibility** — on the rocket you still ride/launch off ramps, grind, loop, and can **fall in pits**. It's a thrilling risk, not a free pass.
- **Satisfying grinds**: the longer you hold a rail the faster the score climbs (rising multiplier — a 4s grind out-scores a 2s grind ~3.75×), with escalating sparks, a rising grind tone, **GRINDING! → ON FIRE! → LEGENDARY!** tiers, and a **PERFECT EXIT!** dismount bonus for popping off in the last slice of the rail.
- **Sonic-style loop-the-loop** in the vert zones — rides the warplet around a neon ring and fires it out with a boost (smooth, snap-free entry/exit).
- Collect **S‑T‑R‑E‑M‑E** letters (slot-tracked so the HUD lights the exact letter grabbed).

### Endless structure & difficulty (researched THPS / OlliOlli / Canabalt / Alto / Sure Footing / Celeste)
- **True endless, one life, beat-the-clock** — no finish line; you skate until you wipe out in a pit or run the clock to zero.
- **Cycling zones** (NEON DOWNTOWN → GRIND DISTRICT → GAP CITY → VERT HEIGHTS → OVERDRIVE → repeat), each with its own interpolated sky/sun palette and set-piece mix; difficulty rides the run clock so later laps get harder.
- **Five-block pacing**: opening tutorial → periodic no-risk **reward** corridors → **challenge** clusters → forced **rest** breathers; no two hard chunks back-to-back; weighting shifts toward harder pieces as you go.
- **Gradual mechanic introduction** (gaps ~16s, stairs/rhythm, kicker-gaps ~38s, loops ~58s) and **speed-scaled telegraphing** (more runway before a hazard the faster you're going).
- **Coyote time** so a late tap off an edge still jumps — one-life deaths always feel earned, never like a dropped input.
- New set pieces: a descending **grind staircase** and cadence **rhythm kickers**.
- HUD: **♥ ONE LIFE** stake, a **☀ N.Ns** clock readout (the sun is the real timer), a looping **zone meter** (current biome + next zone), and `+X.Xs` recharge pops.

### Social / viral
- **Leaderboard** (Redis sorted-set by score, in-memory fallback, Farcaster Quick Auth).
- **Ghost racing** (default ON, Solo optional): your run is recorded and replayed as translucent named racers for the next players.
- **Share**: `composeCast` + dynamic OG card + `?s=<score>&by=&r=` challenge links.

### Warplet PFP gating + Buy $STREME
- Own a **The Warplets** NFT (`0x6997…14b4e`, Base, ERC721Enumerable, on-chain base64 `tokenURI`) **AND** hold ≥10M $STREME or staked → use your warplet as the in-game rider sprite + leaderboard PFP.
- Multi-warplet holders pick which one on a start-screen selector; background is chroma-keyed out for a clean sprite. Same-origin image proxy keeps the canvas untainted.
- **Short on $STREME?** The picker shows a **💰 Buy $STREME** button — in the Farcaster mini-app it opens the native swap sheet (`sdk.actions.swapToken`) without leaving the game; on web it falls back to the `/token/<streme>` page.

### Easter egg
- Tap the title-screen skater **7×** → **🌈 RAD MODE** (rainbow trails) + confetti.

### Notes
- 2D `<canvas>` engine (not Three.js) for the GBA pixel/scanline look; reuses the warplet sprite (`/surf/monster.png`) and theme music (`/surf/theme.mp3`).
- Standalone page reached via Farcaster frame embeds / shared casts — **not** linked from app nav (same as Surf).
- Mechanics verified via a deterministic engine-simulation harness (pit plunge, loop entry/exit, grind escalation + perfect-exit, coyote time, endless zone cycling, navigability, countdown drain/recharge/timeout, turbo ramp-ride + pit-death, sun-as-timer pixel checks); `npm run check:all` ✅ (typecheck + lint).
