### PR TITLE
fix(skate): Warplet images (ipfs gateway race) + carry-forward menu fix

### DIFF
--- a/src/app/api/skate/warplet-image/route.ts
+++ b/src/app/api/skate/warplet-image/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getWarpletImageUri } from "../../../../lib/warplets";
+import { fetchAsset, getWarpletImageUri } from "../../../../lib/warplets";
 
-// Same-origin proxy for a Warplet's on-chain IPFS image so the game <canvas>
-// can use it without tainting (and so <img> thumbnails work everywhere).
+const CACHE = {
+  "Cache-Control": "public, max-age=86400, s-maxage=604800, immutable",
+};
+
+// Same-origin proxy for a Warplet's image (on-chain data URI or IPFS/https) so
+// the game <canvas> can use it without tainting (and so <img> thumbnails work).
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -14,21 +18,31 @@ export async function GET(request: NextRequest) {
     if (!imageUrl) {
       return NextResponse.json({ error: "No image" }, { status: 404 });
     }
-    const res = await fetch(imageUrl, {
-      headers: { Accept: "image/*" },
-      // gateways can be slow; let Next cache the result
-      next: { revalidate: 86400 },
-    });
-    if (!res.ok) {
+
+    // some Warplets embed the art on-chain as a data: URI
+    if (imageUrl.startsWith("data:")) {
+      const m = imageUrl.match(/^data:([^;,]*)(;base64)?,([\s\S]*)$/);
+      if (!m) {
+        return NextResponse.json({ error: "Bad data URI" }, { status: 502 });
+      }
+      const contentType = m[1] || "image/png";
+      const body = m[2]
+        ? Buffer.from(m[3], "base64")
+        : Buffer.from(decodeURIComponent(m[3]), "utf-8");
+      return new NextResponse(body, {
+        headers: { "Content-Type": contentType, ...CACHE },
+      });
+    }
+
+    // ipfs:// or https:// — fetch with multi-gateway fallback
+    const res = await fetchAsset(imageUrl, "image/*");
+    if (!res) {
       return NextResponse.json({ error: "Fetch failed" }, { status: 502 });
     }
     const contentType = res.headers.get("content-type") || "image/png";
     const body = await res.arrayBuffer();
     return new NextResponse(body, {
-      headers: {
-        "Content-Type": contentType,
-        "Cache-Control": "public, max-age=86400, s-maxage=604800, immutable",
-      },
+      headers: { "Content-Type": contentType, ...CACHE },
     });
   } catch (error) {
     console.error("Warplet image error:", error);

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -1207,17 +1207,19 @@ export default function StremeSkateGame({
 
       {/* ---------- start screen (title menu) ---------- */}
       {phase === "ready" && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center pointer-events-none">
-          {/* legibility scrim — keep it dark all the way to the edges so the
-              menu text reads cleanly over the moving course behind it */}
+        <div className="absolute inset-0 pointer-events-none">
+          {/* legibility scrim — sits BEHIND the menu content (the relative z-10
+              wrapper below), so it darkens the moving course, never the text */}
           <div
             className="absolute inset-0 backdrop-blur-[2px]"
             style={{
               background:
-                "radial-gradient(125% 90% at 50% 42%, rgba(6,3,18,0.92) 0%, rgba(6,3,18,0.82) 55%, rgba(6,3,18,0.74) 100%)",
+                "radial-gradient(130% 95% at 50% 42%, rgba(6,3,18,0.85) 0%, rgba(6,3,18,0.7) 60%, rgba(6,3,18,0.6) 100%)",
             }}
           />
 
+          {/* all menu content — layered above the scrim so it stays readable */}
+          <div className="relative z-10 flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
           {/* tagline */}
           <div
             className="rounded-full border border-cyan-300/30 bg-white/5 px-3 py-1 text-[10px] font-bold tracking-[0.34em] text-cyan-200/90"
@@ -1261,8 +1263,9 @@ export default function StremeSkateGame({
           {/* title */}
           <div className="relative" style={{ animation: "skRise 0.55s ease-out both" }}>
             <h1
-              className="text-5xl font-black italic leading-none tracking-tighter"
+              className="whitespace-nowrap font-black italic leading-none tracking-tighter"
               style={{
+                fontSize: "clamp(1.9rem, 9vw, 3rem)",
                 backgroundImage:
                   "linear-gradient(90deg,#67e8f9,#ec4899,#fde68a,#67e8f9)",
                 backgroundSize: "200% auto",
@@ -1342,6 +1345,7 @@ export default function StremeSkateGame({
             >
               {selectedWarplet ? "✨ Warplet" : "🛹 Skater"}
             </button>
+          </div>
           </div>
         </div>
       )}

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -88,9 +88,14 @@ function removeWarpletBg(url: string): Promise<HTMLImageElement> {
           bg += p[o + 1];
           bb += p[o + 2];
         }
+        let ba = 0;
+        for (const o of corners) ba += p[o + 3];
         br /= 4;
         bg /= 4;
         bb /= 4;
+        ba /= 4;
+        // already has a transparent background — leave it as-is
+        if (ba < 32) return resolve(img);
         const TOL = 66 * 66;
         const near = (o: number) => {
           const dr = p[o] - br,
@@ -100,6 +105,7 @@ function removeWarpletBg(url: string): Promise<HTMLImageElement> {
         };
         const visited = new Uint8Array(S * S);
         const stack: number[] = [];
+        let cleared = 0;
         const push = (x: number, y: number) => {
           if (x < 0 || y < 0 || x >= S || y >= S) return;
           const i = y * S + x;
@@ -108,6 +114,7 @@ function removeWarpletBg(url: string): Promise<HTMLImageElement> {
           const o = i * 4;
           if (near(o)) {
             p[o + 3] = 0;
+            cleared++;
             stack.push(x, y);
           }
         };
@@ -123,6 +130,9 @@ function removeWarpletBg(url: string): Promise<HTMLImageElement> {
           push(x, y + 1);
           push(x, y - 1);
         }
+        // if the key matched most of the sprite, the bg wasn't a clean colour —
+        // keep the original rather than show a near-empty rider
+        if (cleared > S * S * 0.92) return resolve(img);
         ctx.putImageData(data, 0, 0);
         const out = new Image();
         out.onload = () => resolve(out);

--- a/src/lib/warplets.ts
+++ b/src/lib/warplets.ts
@@ -59,28 +59,111 @@ export interface WarpletEligibility {
   warplets: WarpletItem[];
 }
 
-/** ipfs://CID (and /ipfs/CID) → a public gateway URL. */
-export function resolveIpfs(uri: string): string {
-  if (!uri) return "";
-  if (uri.startsWith("ipfs://")) {
-    return `https://ipfs.io/ipfs/${uri.slice(7).replace(/^ipfs\//, "")}`;
-  }
-  return uri;
+// Public IPFS gateways, RACED in parallel (first OK wins) so a slow or dead host
+// never blocks a Warplet's image. (cloudflare-ipfs.com is intentionally gone —
+// it was shut down; ipfs.io is kept but often slow, hence the race.)
+const IPFS_GATEWAYS = [
+  "https://gateway.pinata.cloud/ipfs/",
+  "https://dweb.link/ipfs/",
+  "https://ipfs.io/ipfs/",
+  "https://w3s.link/ipfs/",
+  "https://4everland.io/ipfs/",
+];
+
+/** Pull the CID(+path) out of an ipfs://… or …/ipfs/… URL, else null. */
+function ipfsPath(uri: string): string | null {
+  if (uri.startsWith("ipfs://")) return uri.slice(7).replace(/^ipfs\//, "");
+  const m = uri.match(/\/ipfs\/(.+)$/);
+  return m ? m[1] : null;
 }
 
-/** Decode an on-chain `data:application/json;base64,...` tokenURI. */
-function decodeDataUri(uri: string): { name?: string; image?: string } | null {
-  const m = uri.match(/^data:application\/json;base64,(.*)$/);
-  if (!m) return null;
+/** ipfs://CID (and /ipfs/CID) → a public gateway URL (first gateway). */
+export function resolveIpfs(uri: string): string {
+  const path = ipfsPath(uri);
+  return path ? `${IPFS_GATEWAYS[0]}${path}` : uri;
+}
+
+/**
+ * Fetch an asset that may live on IPFS, trying each gateway in turn; `data:` and
+ * plain http(s) URLs are fetched directly. Returns the first OK response, or null.
+ */
+export async function fetchAsset(
+  uri: string,
+  accept: string
+): Promise<Response | null> {
+  const path = ipfsPath(uri);
+  const urls = path ? IPFS_GATEWAYS.map((g) => g + path) : [uri];
+  const attempts = urls.map((url) => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 9000);
+    return fetch(url, { headers: { Accept: accept }, signal: ctrl.signal })
+      .then((res) => {
+        clearTimeout(timer);
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res;
+      })
+      .catch((e) => {
+        clearTimeout(timer);
+        throw e;
+      });
+  });
   try {
-    const json = Buffer.from(m[1], "base64").toString("utf-8");
-    return JSON.parse(json);
+    // first gateway to return OK wins; the slow/dead ones are abandoned
+    return await Promise.any(attempts);
   } catch {
     return null;
   }
 }
 
-/** Read & decode a single Warplet's metadata (used by the image proxy). */
+/** Best-effort SYNC decode of an inline JSON tokenURI (base64 or plain). */
+function decodeDataUri(uri: string): { name?: string; image?: string } | null {
+  const b64 = uri.match(/^data:application\/json;base64,(.*)$/);
+  if (b64) {
+    try {
+      return JSON.parse(Buffer.from(b64[1], "base64").toString("utf-8"));
+    } catch {
+      return null;
+    }
+  }
+  const plain = uri.match(/^data:application\/json(?:;[^,]*)?,([\s\S]*)$/);
+  if (plain) {
+    try {
+      return JSON.parse(decodeURIComponent(plain[1]));
+    } catch {
+      try {
+        return JSON.parse(plain[1]);
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Load a Warplet's metadata from ANY tokenURI shape: on-chain base64 JSON,
+ * on-chain plain/url-encoded JSON, or an off-chain ipfs://… / https://… URL.
+ */
+async function loadMetadata(
+  uri: string
+): Promise<{ name?: string; image?: string } | null> {
+  if (!uri) return null;
+  const inline = decodeDataUri(uri);
+  if (inline) return inline;
+  if (uri.startsWith("ipfs://") || uri.startsWith("http")) {
+    const res = await fetchAsset(uri, "application/json");
+    if (res) {
+      try {
+        return (await res.json()) as { name?: string; image?: string };
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+/** Read & decode a single Warplet's image URI (used by the image proxy). */
 export async function getWarpletImageUri(tokenId: bigint): Promise<string | null> {
   try {
     const uri = (await publicClient.readContract({
@@ -89,8 +172,9 @@ export async function getWarpletImageUri(tokenId: bigint): Promise<string | null
       functionName: "tokenURI",
       args: [tokenId],
     })) as string;
-    const meta = decodeDataUri(uri);
-    return meta?.image ? resolveIpfs(meta.image) : null;
+    const meta = await loadMetadata(uri);
+    // raw image — may be ipfs://, https://, or a data: URI; the proxy resolves it
+    return meta?.image || null;
   } catch {
     return null;
   }


### PR DESCRIPTION
Two fixes for **Streme Skate** (`/skate`), on top of merged [#67](https://github.com/streme-fun/streme-frontend/pull/67).

## 🖼️ Warplet images failing (the main one)
**Root cause, confirmed on-chain:** every Warplet's `tokenURI` is on-chain base64 JSON with an `ipfs://` image, and the image proxy resolved that through a **single gateway — `ipfs.io`** — which **times out for many CIDs**. So any Warplet whose CID `ipfs.io` won't serve looked "not working," while others loaded fine — exactly the reported symptom.

Fix:
- Resolve images across several gateways **raced in parallel** (first OK wins), so a slow/dead host never blocks: `gateway.pinata.cloud`, `dweb.link`, `ipfs.io`, `w3s.link`, `4everland.io`. Dropped `cloudflare-ipfs.com` (it was shut down). 9 s per-gateway abort.
- Hardened metadata decoding to also accept plain/url-encoded `data:` JSON and **off-chain** `ipfs://…` / `https://…` tokenURIs, and let the proxy serve on-chain `data:` images directly (future-proofing other collections / migrations).
- `removeWarpletBg`: skip the chroma-key when the art already has a transparent background, and fall back to the original if the key would erase >92% of the sprite — so a non-uniform background never yields a blank rider.

**Verified:** four real tokens (`1725`, `436728`, `491612`, `1185058`) that returned **502 timeouts** on the old single-gateway path now return valid **PNG/JPG** (HTTP 200) through the proxy.

## 📖 Title menu (carried forward)
PR #67's squash didn't include my menu fix, so **prod currently has the unusable menu** — the opaque scrim (an `absolute` element) paints *over* the static menu controls, burying the Best chip, the control hints, and the Ghosts/Skater buttons. This re-applies the fix: wrap all menu content in a `relative z-10` layer above the scrim, and clamp the logo (`clamp(1.9rem, 9vw, 3rem)`) so "STREME SKATE" stops clipping wide phones. Verified readable + non-clipping at 375 px and 430 px.

`npm run check:all` ✅ (typecheck + lint).
