### PR TITLE
feat(skate): cache-bust the share OG image per deploy

### DIFF
--- a/src/app/api/skate/image/route.tsx
+++ b/src/app/api/skate/image/route.tsx
@@ -6,7 +6,10 @@ import { NextRequest } from "next/server";
 import { SKATE_DISPLAY_URL } from "../../../../lib/skateShare";
 
 export const runtime = "edge";
-export const dynamic = "force-dynamic";
+// The render is a pure function of the query params (s / by / r / v), and the
+// page meta stamps a per-deploy `v` token onto the URL, so a given URL is stable
+// within a deploy. Let the CDN cache each URL (see Cache-Control below) instead
+// of forcing a fresh ~1200×800 Satori render on every Farcaster / link scrape.
 
 export async function GET(request: NextRequest) {
   const host = request.headers.get("host");
@@ -172,6 +175,16 @@ export async function GET(request: NextRequest) {
         </div>
       </div>
     ),
-    { width: 1200, height: 800 }
+    {
+      width: 1200,
+      height: 800,
+      headers: {
+        // Cache hard at the CDN (each URL is deploy-stable thanks to the `v`
+        // token) and serve stale while revalidating, so a deploy that changes
+        // the card art naturally rolls in with the next scrape.
+        "Cache-Control":
+          "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    }
   );
 }

--- a/src/app/skate/page.tsx
+++ b/src/app/skate/page.tsx
@@ -3,6 +3,16 @@ import SkatePageClient from "./SkatePageClient";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
 
+// Cache-busting token appended to the OG image URL. Vercel sets
+// VERCEL_GIT_COMMIT_SHA per deploy, so every deploy yields a fresh image URL —
+// Farcaster / CDN scrapers re-fetch the new render instead of serving a stale
+// one when the card art changes. Set NEXT_PUBLIC_OG_VERSION to force a bust
+// without a deploy (e.g. after swapping the background asset).
+const OG_VERSION =
+  process.env.NEXT_PUBLIC_OG_VERSION ||
+  process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) ||
+  "dev";
+
 interface Props {
   searchParams: Promise<{ s?: string; by?: string; r?: string }>;
 }
@@ -42,9 +52,8 @@ export async function generateMetadata({
     if (challenge.by) imageParams.set("by", challenge.by);
     if (challenge.rank) imageParams.set("r", String(challenge.rank));
   }
-  const imageUrl = `${baseUrl}/api/skate/image${
-    imageParams.size > 0 ? `?${imageParams.toString()}` : ""
-  }`;
+  imageParams.set("v", OG_VERSION);
+  const imageUrl = `${baseUrl}/api/skate/image?${imageParams.toString()}`;
 
   const pageParams = new URLSearchParams();
   if (challenge) {


### PR DESCRIPTION
## Why
Follow-up to #69. When the skate OG card art changed, Farcaster and the CDN kept serving the **stale** render — the image URL was stable (especially the no-score default `/api/skate/image`), and `next/og`'s `ImageResponse` ships a long default `Cache-Control`. So updated art never showed up in previews.

## What
**Per-deploy version token** (`src/app/skate/page.tsx`)
- Stamp `&v=<token>` onto the `og:image` and `fc:frame` image URL.
- Token = `VERCEL_GIT_COMMIT_SHA` (first 8 chars), overridable via `NEXT_PUBLIC_OG_VERSION` to force a bust without a deploy (e.g. after swapping the background asset), falling back to `dev` locally.
- Every deploy → fresh image URL → scrapers re-fetch instead of serving a cached old render. Applies to both the score/challenge card and the default card.

**Controlled caching** (`src/app/api/skate/image/route.tsx`)
- The render is a pure function of `s / by / r / v`, so each URL is deterministic and deploy-stable. Dropped `force-dynamic` and set an explicit header:
  `Cache-Control: public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800`.
- The CDN now caches each card instead of re-rendering a ~1200×800 Satori image on every scrape; art changes roll in with the next deploy.

The route ignores the extra `v` param (it only reads `s`/`by`/`r`), so old already-posted casts keep rendering fine.

## Testing
Rendered locally against the dev server:
- `GET /api/skate/image?s=1284500&by=lee&r=3&v=abc12345` → `200`, `content-type: image/png`, and `cache-control: public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800`. Card renders correctly (v ignored).
- `/skate?s=…` and `/skate` page meta now emit `…/api/skate/image?…&v=dev` in both `og:image` and `fc:frame`.
- `eslint` clean on both files.

> Note: already-posted casts can't be retroactively updated (their embed + Farcaster's cached scrape are fixed) — this ensures every **new** share and any fresh scrape after a deploy reflects the current art.