### PR TITLE
fix(skate): robust leaderboard + ghosts that do tricks

### DIFF
--- a/src/app/api/skate/leaderboard/route.ts
+++ b/src/app/api/skate/leaderboard/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
     const fidParam = Number(searchParams.get("fid"));
     const fid =
       Number.isInteger(fidParam) && fidParam > 0 ? fidParam : undefined;
-    const data = await getSkateLeaderboard(10, fid);
+    const data = await getSkateLeaderboard(25, fid);
     return NextResponse.json(data, {
       headers: {
         "Cache-Control": "public, s-maxage=15, stale-while-revalidate=60",

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -126,8 +126,13 @@ interface Ghost {
   samples: number[];
   color: string;
   name?: string;
+  spin: number; // flip direction (±1) for inferred trick playback
 }
 const GHOST_DT = 0.15; // seconds between recorded ghost samples
+// Ghost recordings only store [px,py], so we infer tricks: once a ghost rises
+// clearly above the rails (~64-88px) it's mid-jump, so spin it through whole
+// rotations (landing flat) instead of just floating up and down.
+const GHOST_AIR_SPIN = 95;
 const GHOST_COLORS = ["#fb7185", "#a78bfa", "#34d399", "#fbbf24", "#38bdf8"];
 
 const BASE_SPEED = 300;
@@ -597,6 +602,7 @@ export class SkateGameEngine {
       samples: g.samples,
       color: g.color || GHOST_COLORS[i % GHOST_COLORS.length],
       name: g.name,
+      spin: i % 2 === 0 ? -1 : 1, // alternate back/front flips for variety
     }));
   }
 
@@ -2209,9 +2215,42 @@ export class SkateGameEngine {
       const px = this.sx(gx);
       if (px < -40 || px > this.W + 40) continue;
       const py = this.groundY - gy;
+
+      // Infer a trick: while a ghost is well above the rails it's mid-jump, so
+      // spin it through whole rotations and land it flat. Progress is measured
+      // across the contiguous airborne segment, so rot hits 0 at both ends
+      // (continuous with the flat ground/grind sections). Grinds stay flat.
+      let rot = 0;
+      if (gy > GHOST_AIR_SPIN) {
+        // Bound the airborne run, then find the exact times gy crosses the
+        // threshold so the spin starts and ends flat (a whole number of
+        // rotations) — no snap as the ghost touches down.
+        const sy = (k: number) => g.samples[k * 2 + 1];
+        let a = sy(ia) > GHOST_AIR_SPIN ? ia : ib;
+        let b = a;
+        while (a > 0 && sy(a - 1) > GHOST_AIR_SPIN) a--;
+        while (b < n - 1 && sy(b + 1) > GHOST_AIR_SPIN) b++;
+        let tEnter = a;
+        if (a > 0)
+          tEnter = a - 1 + (GHOST_AIR_SPIN - sy(a - 1)) / (sy(a) - sy(a - 1));
+        let tExit = b;
+        if (b < n - 1)
+          tExit = b + (sy(b) - GHOST_AIR_SPIN) / (sy(b) - sy(b + 1));
+        const dur = tExit - tEnter;
+        if (dur > 1e-3) {
+          const prog = Math.min(Math.max((t - tEnter) / dur, 0), 1);
+          const flips = Math.max(
+            1,
+            Math.min(3, Math.round((dur * GHOST_DT) / 0.45))
+          );
+          rot = g.spin * prog * flips * Math.PI * 2;
+        }
+      }
+
       ctx.save();
       ctx.translate(px, py);
       ctx.globalAlpha = 0.4;
+      // ground glow — stays flat beneath the trick
       ctx.shadowColor = g.color;
       ctx.shadowBlur = 8;
       ctx.fillStyle = g.color;
@@ -2219,12 +2258,18 @@ export class SkateGameEngine {
       ctx.ellipse(0, 6, 15, 5, 0, 0, Math.PI * 2);
       ctx.fill();
       ctx.shadowBlur = 0;
+      // rider + board, flipped around the body's middle
+      ctx.save();
+      ctx.translate(0, -10);
+      ctx.rotate(rot);
+      ctx.translate(0, 10);
       ctx.fillStyle = "#cbd5e1";
       ctx.fillRect(-15, 4, 30, 4);
       if (this.monster) {
         ctx.imageSmoothingEnabled = false;
         ctx.drawImage(this.monster, -16, -28, 32, 32);
       }
+      ctx.restore();
       ctx.globalAlpha = 1;
       if (g.name) {
         ctx.globalAlpha = 0.85;

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -1604,7 +1604,7 @@ export default function StremeSkateGame({
                 </p>
               )}
             </div>
-            {board?.player && board.player.rank > 10 && (
+            {board?.player && board.player.rank > board.entries.length && (
               <div className="mt-2 rounded-lg bg-primary/10 px-3 py-2 text-center font-mono text-sm">
                 You: #{board.player.rank} · {board.player.best.toLocaleString()}
               </div>

--- a/src/lib/skateLeaderboard.ts
+++ b/src/lib/skateLeaderboard.ts
@@ -56,11 +56,16 @@ export async function submitSkateScore(
       });
       await redis.hset(playerKey(entry.fid), { ...entry, updatedAt: now });
     } else {
-      // Keep profile fresh even when the score doesn't improve
-      await redis.hset(playerKey(entry.fid), {
-        username: entry.username,
-        pfpUrl: entry.pfpUrl,
-      });
+      // Keep the profile fresh even when the score doesn't improve — but never
+      // blank out good data: a run can arrive with an empty username/pfp (e.g.
+      // the Warplet image didn't resolve), and overwriting with "" would make a
+      // ranked player render nameless/avatarless ("disappear").
+      const profile: Record<string, string> = {};
+      if (entry.username) profile.username = entry.username;
+      if (entry.pfpUrl) profile.pfpUrl = entry.pfpUrl;
+      if (Object.keys(profile).length > 0) {
+        await redis.hset(playerKey(entry.fid), profile);
+      }
     }
     const [rank, total] = await Promise.all([
       redis.zrevrank(BOARD_KEY, String(entry.fid)),
@@ -89,7 +94,7 @@ export async function submitSkateScore(
 }
 
 export async function getSkateLeaderboard(
-  limit = 10,
+  limit = 25,
   fid?: number
 ): Promise<{
   entries: SkateEntry[];
@@ -97,27 +102,37 @@ export async function getSkateLeaderboard(
   total: number;
 }> {
   if (redis) {
-    const members = await redis.zrange<string[]>(BOARD_KEY, 0, limit - 1, {
-      rev: true,
-    });
+    // Pull members WITH their sorted-set scores. The zset is the source of truth
+    // for both ranking and the displayed score, so a missing/stale profile hash
+    // can never drop a ranked player off the board (the old code skipped any
+    // member whose hgetall came back empty, leaving gaps).
+    const ranked = (await redis.zrange<(string | number)[]>(
+      BOARD_KEY,
+      0,
+      limit - 1,
+      { rev: true, withScores: true }
+    )) as (string | number)[];
+    const members: { fid: number; score: number }[] = [];
+    for (let i = 0; i < ranked.length; i += 2) {
+      members.push({ fid: Number(ranked[i]), score: Number(ranked[i + 1]) });
+    }
     const entries: SkateEntry[] = [];
     if (members.length > 0) {
       const pipeline = redis.pipeline();
-      for (const member of members) {
-        pipeline.hgetall(playerKey(Number(member)));
+      for (const m of members) {
+        pipeline.hgetall(playerKey(m.fid));
       }
       const rows = await pipeline.exec<(Record<string, unknown> | null)[]>();
-      rows.forEach((row, i) => {
-        if (row) {
-          entries.push({
-            fid: Number(members[i]),
-            username: String(row.username ?? ""),
-            pfpUrl: String(row.pfpUrl ?? ""),
-            score: Number(row.score ?? 0),
-            combo: Number(row.combo ?? 0),
-            updatedAt: Number(row.updatedAt ?? 0),
-          });
-        }
+      members.forEach((m, i) => {
+        const row = rows[i] ?? {};
+        entries.push({
+          fid: m.fid,
+          username: String(row.username ?? ""),
+          pfpUrl: String(row.pfpUrl ?? ""),
+          score: m.score, // zset score is authoritative
+          combo: Number(row.combo ?? 0),
+          updatedAt: Number(row.updatedAt ?? 0),
+        });
       });
     }
     const total = await redis.zcard(BOARD_KEY);


### PR DESCRIPTION
Two unrelated skate fixes.

## 1. Leaderboard "left off someone I saw before"
Live data showed a clean top-10 but **12 total** — the board was hardcoded to 10, so players at rank 11+ were windowed out as new high scores arrived. Hardened the fetch + display:

- **Show top 25** (was 10). The modal already scrolls.
- **Never silently drop a ranked player.** `getSkateLeaderboard` now reads members `withScores` and uses the **sorted set as the source of truth** for both rank and displayed score. The old code skipped any member whose profile-hash `hgetall` came back empty (`if (row)`), leaving a gap — now a missing/stale hash just renders with the fid + zset score instead of vanishing.
- **No more profile blanking.** A non-improved submit used to overwrite `username`/`pfpUrl` with empty strings (e.g. when a Warplet image didn't resolve), making a ranked player render nameless/avatarless. Now it only writes non-empty fields.
- The **"You: #N"** footer keys off the visible-list length instead of a hardcoded `10`.

## 2. Ghosts now do tricks instead of just jumping
Ghost recordings are position-only (`[px, py]`), so ghosts only translated up and down. Rather than migrate the data, tricks are **inferred on playback**:

- Once a ghost rises clearly above the rails (~64–88px → threshold 95) it's mid-jump, so it spins through **whole rotations**.
- Rotation is driven by progress between the exact times `gy` crosses the air threshold, so the spin **starts and ends flat** (a whole number of turns) with no snap on landing. Grinds and ground rolling stay flat.
- Air time picks **1–3 flips**; flip direction alternates per ghost for variety. The board + rider rotate together around the body's center.
- Works for **all 80 existing recordings** — no format change, no migration.

## Testing
- Leaderboard logic verified against the live board (10 shown / 12 total → all now visible at 25). Confirmed the installed `@upstash/redis` (v1.36.1) `zrange(..., { withScores: true })` returns the flat `[member, score, …]` shape the new code parses.
- Ghost rotation math validated with a deterministic sweep over a synthetic jump+grind arc: flat on ground/grind, spins only mid-air, lands on a whole rotation (continuous, no snap), NaN-free.
- `eslint` + `tsc` clean on all changed files.

> Note: ghost flips only become visible once this deploys (recorded ghosts live in prod KV; the dev namespace is empty), so they couldn't be screenshotted pre-merge.