### PR TITLE
feat(skate): DAILY LINE — shared daily course, one counted run, rivals + streaks

### DIFF
--- a/__tests__/lib/skateDaily.test.ts
+++ b/__tests__/lib/skateDaily.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  dailyEndsAt,
+  dailyKey,
+  dailyName,
+  dailySeed,
+  formatTimeLeft,
+  isDailyKey,
+  prevDailyKey,
+} from "@/src/lib/skateDaily";
+import { buildDailyShareIntent, SKATE_SHARE_URL } from "@/src/lib/skateShare";
+
+describe("skateDaily", () => {
+  it("derives a stable UTC day key", () => {
+    expect(dailyKey(new Date("2026-06-12T23:59:59Z"))).toBe("2026-06-12");
+    expect(dailyKey(new Date("2026-06-13T00:00:01Z"))).toBe("2026-06-13");
+    expect(isDailyKey("2026-06-12")).toBe(true);
+    expect(isDailyKey("not-a-day")).toBe(false);
+  });
+
+  it("maps a day key to one deterministic 31-bit seed — the same line for everyone", () => {
+    const a = dailySeed("2026-06-12");
+    const b = dailySeed("2026-06-12");
+    const c = dailySeed("2026-06-13");
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toBeGreaterThan(0);
+    expect(a).toBeLessThanOrEqual(0x7fffffff);
+  });
+
+  it("names the line by weekday and closes it at the next UTC midnight", () => {
+    expect(dailyName("2026-06-12")).toBe("FRIDAY FAKIE"); // 2026-06-12 is a Friday
+    expect(prevDailyKey("2026-06-12")).toBe("2026-06-11");
+    expect(dailyEndsAt("2026-06-12")).toBe(
+      new Date("2026-06-13T00:00:00Z").getTime()
+    );
+  });
+
+  it("formats the reset countdown", () => {
+    const ends = new Date("2026-06-13T00:00:00Z").getTime();
+    const now = new Date("2026-06-12T16:48:00Z").getTime();
+    expect(formatTimeLeft(ends, now)).toBe("7h 12m");
+    expect(formatTimeLeft(ends, ends + 1000)).toBe("0m");
+  });
+});
+
+describe("buildDailyShareIntent", () => {
+  it("stamps the day onto the share URL so the cast is a live dare", () => {
+    const share = buildDailyShareIntent({
+      score: 138328,
+      day: "2026-06-12",
+      name: "FRIDAY FAKIE",
+      username: "lee",
+      rank: 1,
+      total: 7,
+      streak: 3,
+    });
+
+    expect(share.shareUrl).toBe(
+      `${SKATE_SHARE_URL}?d=2026-06-12&s=138328&by=lee&r=1&st=3`
+    );
+    expect(share.castText).toContain("DAILY LINE · FRIDAY FAKIE");
+    expect(share.castText).toContain("#1 of 7");
+    expect(share.castText).toContain("3-day streak");
+    expect(share.castText).toContain(share.shareUrl);
+  });
+
+  it("omits rank and streak chips it cannot vouch for", () => {
+    const share = buildDailyShareIntent({
+      score: 5000,
+      day: "2026-06-12",
+      name: "FRIDAY FAKIE",
+      streak: 1, // a 1-day streak is just "played today" — not worth bragging
+    });
+
+    expect(share.shareUrl).toBe(`${SKATE_SHARE_URL}?d=2026-06-12&s=5000`);
+    expect(share.castText).not.toContain("streak");
+    expect(share.castText).not.toContain("#");
+  });
+});

--- a/src/app/api/skate/daily/route.ts
+++ b/src/app/api/skate/daily/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, Errors } from "@farcaster/quick-auth";
+import {
+  dailyEndsAt,
+  dailyKey,
+  dailyName,
+  dailySeed,
+  isDailyKey,
+  prevDailyKey,
+} from "../../../../lib/skateDaily";
+import {
+  getDailyBoard,
+  submitDailyRun,
+} from "../../../../lib/skateDailyBoard";
+
+const MAX_SCORE = 100_000_000;
+const MAX_COMBO = 50_000_000;
+// a run that started before midnight UTC may finish just after — accept it
+// onto the day it was actually skated for a short grace window
+const ROLLOVER_GRACE_MS = 10 * 60 * 1000;
+
+async function authenticateFid(request: NextRequest): Promise<number | null> {
+  if (process.env.NODE_ENV !== "production") {
+    const devFid = Number(request.headers.get("x-dev-fid"));
+    if (Number.isInteger(devFid) && devFid > 0) return devFid;
+  }
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  const token = authHeader.substring(7);
+  try {
+    const client = createClient();
+    const payload = await client.verifyJwt({
+      token,
+      domain: request.headers.get("host") || "streme.fun",
+    });
+    const fid = Number(payload.sub);
+    return Number.isInteger(fid) && fid > 0 ? fid : null;
+  } catch (e) {
+    if (e instanceof Errors.InvalidTokenError) return null;
+    throw e;
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const fidParam = Number(searchParams.get("fid"));
+    const fid =
+      Number.isInteger(fidParam) && fidParam > 0 ? fidParam : undefined;
+
+    const day = dailyKey();
+    const board = await getDailyBoard(day, fid);
+    return NextResponse.json(
+      {
+        day,
+        name: dailyName(day),
+        seed: dailySeed(day),
+        endsAt: dailyEndsAt(day),
+        ...board,
+      },
+      // attempt state must never go stale on the client — keep this uncached
+      { headers: { "Cache-Control": "no-store" } }
+    );
+  } catch (error) {
+    console.error("Skate daily GET error:", error);
+    return NextResponse.json(
+      { error: "Failed to load daily line" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const fid = await authenticateFid(request);
+    if (!fid) {
+      return NextResponse.json(
+        { error: "Authorization required" },
+        { status: 401 }
+      );
+    }
+
+    const body = (await request.json()) as {
+      day?: unknown;
+      score?: unknown;
+      combo?: unknown;
+      username?: unknown;
+      pfpUrl?: unknown;
+      samples?: unknown;
+    };
+
+    const today = dailyKey();
+    const claimedDay = typeof body.day === "string" ? body.day : today;
+    if (!isDailyKey(claimedDay)) {
+      return NextResponse.json({ error: "Invalid day" }, { status: 400 });
+    }
+    const sinceMidnight = Date.now() - dailyEndsAt(prevDailyKey(today));
+    const dayOk =
+      claimedDay === today ||
+      (claimedDay === prevDailyKey(today) && sinceMidnight < ROLLOVER_GRACE_MS);
+    if (!dayOk) {
+      return NextResponse.json(
+        { error: "That line has reset — play today's" },
+        { status: 409 }
+      );
+    }
+
+    const score = Math.floor(Number(body.score));
+    if (!Number.isFinite(score) || score <= 0 || score > MAX_SCORE) {
+      return NextResponse.json({ error: "Invalid score" }, { status: 400 });
+    }
+    const combo = Math.min(
+      Math.max(Math.floor(Number(body.combo)) || 0, 0),
+      MAX_COMBO
+    );
+    const username =
+      typeof body.username === "string" ? body.username.slice(0, 32) : "";
+    const pfpUrl =
+      typeof body.pfpUrl === "string" && body.pfpUrl.startsWith("https://")
+        ? body.pfpUrl.slice(0, 300)
+        : "";
+    const samples = Array.isArray(body.samples)
+      ? body.samples
+          .slice(0, 1400)
+          .map((n) => Number(n))
+          .filter((n) => Number.isFinite(n))
+      : [];
+
+    const result = await submitDailyRun(
+      claimedDay,
+      { fid, username, pfpUrl, score, combo },
+      samples
+    );
+    return NextResponse.json(
+      { day: claimedDay, name: dailyName(claimedDay), ...result },
+      { status: result.alreadyPlayed ? 409 : 200 }
+    );
+  } catch (error) {
+    console.error("Skate daily POST error:", error);
+    return NextResponse.json(
+      { error: "Failed to submit daily run" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/skate/image/route.tsx
+++ b/src/app/api/skate/image/route.tsx
@@ -4,6 +4,11 @@
 import { ImageResponse } from "next/og";
 import { NextRequest } from "next/server";
 import { SKATE_DISPLAY_URL } from "../../../../lib/skateShare";
+import {
+  dailyName,
+  formatDailyDate,
+  isDailyKey,
+} from "../../../../lib/skateDaily";
 
 export const runtime = "edge";
 // The render is a pure function of the query params (s / by / r / v), and the
@@ -28,6 +33,13 @@ export async function GET(request: NextRequest) {
   const rank =
     Number.isInteger(rankParam) && rankParam > 0 && rankParam <= 10_000
       ? rankParam
+      : null;
+  const dayRaw = searchParams.get("d") ?? "";
+  const day = isDailyKey(dayRaw) ? dayRaw : null;
+  const streakParam = Number(searchParams.get("st"));
+  const streak =
+    day && Number.isInteger(streakParam) && streakParam > 1 && streakParam <= 999
+      ? streakParam
       : null;
 
   return new ImageResponse(
@@ -102,6 +114,26 @@ export async function GET(request: NextRequest) {
             >
               STREME SKATE
             </div>
+            {day && (
+              <div
+                style={{
+                  display: "flex",
+                  alignSelf: "flex-start",
+                  alignItems: "center",
+                  marginTop: 4,
+                  padding: "8px 22px",
+                  borderRadius: 999,
+                  background: "rgba(253, 230, 138, 0.16)",
+                  border: "2px solid #fde68a",
+                  fontSize: 30,
+                  fontWeight: 800,
+                  letterSpacing: 2,
+                  color: "#fde68a",
+                }}
+              >
+                ⚡ DAILY LINE · {dailyName(day)} · {formatDailyDate(day)}
+              </div>
+            )}
             {score ? (
               <div style={{ display: "flex", flexDirection: "column" }}>
                 <div
@@ -124,24 +156,46 @@ export async function GET(request: NextRequest) {
                     marginTop: 6,
                   }}
                 >
-                  {by ? `@${by} dares you to beat it` : "Can you beat this line?"}
+                  {day
+                    ? `${by ? `@${by}` : "Someone"} dares you — one shot a day`
+                    : by
+                    ? `@${by} dares you to beat it`
+                    : "Can you beat this line?"}
                 </div>
-                {rank && (
-                  <div
-                    style={{
-                      display: "flex",
-                      alignSelf: "flex-start",
-                      marginTop: 18,
-                      padding: "10px 26px",
-                      borderRadius: 999,
-                      background: "rgba(103, 232, 249, 0.15)",
-                      border: "2px solid #67e8f9",
-                      fontSize: 34,
-                      fontWeight: 700,
-                      color: "#67e8f9",
-                    }}
-                  >
-                    #{rank} on the leaderboard
+                {(rank || streak) && (
+                  <div style={{ display: "flex", marginTop: 18, gap: 14 }}>
+                    {rank && (
+                      <div
+                        style={{
+                          display: "flex",
+                          padding: "10px 26px",
+                          borderRadius: 999,
+                          background: "rgba(103, 232, 249, 0.15)",
+                          border: "2px solid #67e8f9",
+                          fontSize: 34,
+                          fontWeight: 700,
+                          color: "#67e8f9",
+                        }}
+                      >
+                        #{rank} {day ? "today" : "on the leaderboard"}
+                      </div>
+                    )}
+                    {streak && (
+                      <div
+                        style={{
+                          display: "flex",
+                          padding: "10px 26px",
+                          borderRadius: 999,
+                          background: "rgba(251, 146, 60, 0.15)",
+                          border: "2px solid #fb923c",
+                          fontSize: 34,
+                          fontWeight: 700,
+                          color: "#fb923c",
+                        }}
+                      >
+                        🔥 {streak}-day streak
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/src/app/skate/page.tsx
+++ b/src/app/skate/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import SkatePageClient from "./SkatePageClient";
+import { dailyKey, dailyName, isDailyKey } from "../../lib/skateDaily";
 
 const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://streme.fun";
 
@@ -14,10 +15,15 @@ const OG_VERSION =
   "dev";
 
 interface Props {
-  searchParams: Promise<{ s?: string; by?: string; r?: string }>;
+  searchParams: Promise<{ s?: string; by?: string; r?: string; d?: string }>;
 }
 
-function parseChallenge(params: { s?: string; by?: string; r?: string }) {
+function parseChallenge(params: {
+  s?: string;
+  by?: string;
+  r?: string;
+  d?: string;
+}) {
   const score = Number(params.s);
   if (!Number.isFinite(score) || score <= 0 || score > 100_000_000) {
     return null;
@@ -27,10 +33,13 @@ function parseChallenge(params: { s?: string; by?: string; r?: string }) {
       ? params.by
       : undefined;
   const rank = Number(params.r);
+  const day =
+    typeof params.d === "string" && isDailyKey(params.d) ? params.d : undefined;
   return {
     score: Math.floor(score),
     by,
     rank: Number.isInteger(rank) && rank > 0 ? rank : undefined,
+    day,
   };
 }
 
@@ -38,12 +47,21 @@ export async function generateMetadata({
   searchParams,
 }: Props): Promise<Metadata> {
   const challenge = parseChallenge(await searchParams);
+  const isLiveDaily = Boolean(challenge?.day && challenge.day === dailyKey());
 
-  const title = "Streme Skate - Grind the Stream";
+  const title = isLiveDaily
+    ? "Streme Skate — Daily Line"
+    : "Streme Skate - Grind the Stream";
   const description = challenge
-    ? `Someone${
-        challenge.by ? ` (@${challenge.by})` : ""
-      } scored ${challenge.score.toLocaleString()} in Streme Skate. Think you can beat it?`
+    ? challenge.day
+      ? `${
+          challenge.by ? `@${challenge.by}` : "Someone"
+        } scored ${challenge.score.toLocaleString()} on the ${dailyName(
+          challenge.day
+        )} daily line. Same course for everyone, one counted shot a day — beat it before it resets.`
+      : `Someone${
+          challenge.by ? ` (@${challenge.by})` : ""
+        } scored ${challenge.score.toLocaleString()} in Streme Skate. Think you can beat it?`
     : "A neon, GBA-style skate trick-attack. Ollie ramps, flip in the air, grind the streams, and stack combos. How high can you score?";
 
   const imageParams = new URLSearchParams();
@@ -51,6 +69,7 @@ export async function generateMetadata({
     imageParams.set("s", String(challenge.score));
     if (challenge.by) imageParams.set("by", challenge.by);
     if (challenge.rank) imageParams.set("r", String(challenge.rank));
+    if (challenge.day) imageParams.set("d", challenge.day);
   }
   imageParams.set("v", OG_VERSION);
   const imageUrl = `${baseUrl}/api/skate/image?${imageParams.toString()}`;
@@ -59,6 +78,7 @@ export async function generateMetadata({
   if (challenge) {
     pageParams.set("s", String(challenge.score));
     if (challenge.by) pageParams.set("by", challenge.by);
+    if (challenge.day) pageParams.set("d", challenge.day);
   }
   const pageUrl = `${baseUrl}/skate${
     pageParams.size > 0 ? `?${pageParams.toString()}` : ""
@@ -68,7 +88,9 @@ export async function generateMetadata({
     version: "next",
     imageUrl,
     button: {
-      title: challenge
+      title: isLiveDaily
+        ? "⚡ Beat today's line"
+        : challenge
         ? `🛹 Beat ${challenge.score.toLocaleString()}`
         : "🛹 Play Streme Skate",
       action: {

--- a/src/components/skate/SkateGameEngine.ts
+++ b/src/components/skate/SkateGameEngine.ts
@@ -86,6 +86,14 @@ interface Ramp {
   xLip: number;
   height: number;
   launch: number;
+  vcap?: number; // per-ramp launch velocity ceiling (vert walls fire higher)
+}
+interface Slope {
+  // a descending landing wedge — drops from `height` at x0 to street level at
+  // x1. Land on its face for a HILL BOMB momentum surge; riding it adds speed.
+  x0: number;
+  x1: number;
+  height: number;
 }
 interface Loop {
   x: number; // entry x (bottom of the loop)
@@ -170,6 +178,12 @@ const BOOST_SICK = 90;
 const BOOST_DECAY = 150;
 const BOOST_CAP = 300;
 
+// terrain momentum (Tiny Wings / Alto): riding a downslope pulls you faster,
+// and stomping a landing ONTO a downslope face pays a HILL BOMB surge
+const SLOPE_GRAVITY = 190; // extra accel (px/s²) while riding a downslope
+const SLOPE_BOMB_BOOST = 120;
+const SLOPE_BOMB_SPEED = 60;
+
 const MAGNET_T = 6;
 const MAGNET_R = 175;
 const ROCKET_T = 3.2;
@@ -189,6 +203,10 @@ const FLIP_NAMES = ["KICKFLIP", "360 FLIP", "BACKFLIP", "VARIAL", "HARDFLIP"];
 // Endless — themed zones cycle forever (~ZONE_LEN px each), each with its own
 // sky/sun palette (visual variety) and set-piece weight mix (gameplay variety).
 // Later cycles are harder because difficulty rides the run clock, not position.
+// Zones also carry SIGNATURE set pieces so each biome plays differently, not
+// just looks different: GAP CITY runs mega-ramps (kicker → gap → landing
+// slope), VERT HEIGHTS runs sky-high vert walls, OVERDRIVE runs flowlines
+// (kicker → downslope momentum cadence).
 const ZONE_LEN = 7200; // world px per zone before it transitions to the next
 const START_LIVES = 1; // one life — endless, you go till you wipe out
 
@@ -229,7 +247,7 @@ const ZONES: Zone[] = [
       sky: [[26, 8, 38], [74, 18, 48], [209, 69, 58], [240, 138, 42]],
       sun: [[254, 240, 138], [251, 146, 60], [239, 68, 68], [136, 19, 55]],
     },
-    mix: { gap: 1.8, kickerGap: 1.8, doubleKicker: 1.2, kickerAir: 0.9, rail: 0.7, flat: 0.7 },
+    mix: { gap: 1.8, kickerGap: 1.4, megaRamp: 1.7, doubleKicker: 1.2, kickerAir: 0.9, rail: 0.7, flat: 0.7 },
   },
   {
     name: "VERT HEIGHTS",
@@ -238,7 +256,7 @@ const ZONES: Zone[] = [
       sky: [[12, 6, 38], [42, 13, 84], [122, 31, 174], [192, 38, 160]],
       sun: [[244, 114, 182], [219, 39, 119], [168, 85, 247], [88, 28, 135]],
     },
-    mix: { quarter: 1.6, kickerAir: 1.6, kickerRail: 1.4, stairs: 1.2, doubleKicker: 1.2, kickerGap: 1.0, loop: 1.0, flat: 0.6 },
+    mix: { vertWall: 1.8, quarter: 1.2, kickerAir: 1.6, kickerRail: 1.4, stairs: 1.2, doubleKicker: 1.2, kickerGap: 1.0, loop: 1.0, flat: 0.6 },
   },
   {
     name: "OVERDRIVE",
@@ -247,7 +265,7 @@ const ZONES: Zone[] = [
       sky: [[22, 8, 38], [90, 18, 64], [236, 72, 153], [251, 191, 36]],
       sun: [[253, 230, 138], [244, 114, 182], [239, 68, 68], [124, 28, 92]],
     },
-    mix: { quarter: 1.4, kickerGap: 1.4, kickerAir: 1.3, rhythm: 1.2, doubleKicker: 1.2, rail: 1.0, gap: 1.2, kickerRail: 1.2, loop: 1.1 },
+    mix: { flowline: 1.5, quarter: 1.4, kickerGap: 1.4, kickerAir: 1.3, rhythm: 1.2, doubleKicker: 1.2, rail: 1.0, gap: 1.2, kickerRail: 1.2, loop: 1.1 },
   },
 ];
 
@@ -307,6 +325,7 @@ export class SkateGameEngine {
   private letters: Letter[] = [];
   private powers: Power[] = [];
   private ramps: Ramp[] = [];
+  private slopes: Slope[] = [];
   private loops: Loop[] = [];
   private loopActive: Loop | null = null;
   private loopT = 0;
@@ -525,6 +544,7 @@ export class SkateGameEngine {
     this.gaps = [];
     this.rails = [];
     this.ramps = [];
+    this.slopes = [];
     this.loops = [];
     this.loopActive = null;
     this.loopT = 0;
@@ -760,16 +780,54 @@ export class SkateGameEngine {
 
   // ----------------------------------------------------------- course gen
 
+  // TWO RNG streams. The course stream is reset to `baseSeed` on every prime,
+  // so a given seed always lays the SAME line — which is what makes the DAILY
+  // LINE (one shared seed for everyone) and ghost-course alignment work. The
+  // FX stream feeds particles/shake and is never reset: visuals must not be
+  // able to perturb the course.
   private rand(n: number): number {
-    this.waveSeed = (this.waveSeed * 1103515245 + 12345) & 0x7fffffff;
-    return (this.waveSeed / 0x7fffffff) * n;
+    this.fxSeed = (this.fxSeed * 1103515245 + 12345) & 0x7fffffff;
+    return (this.fxSeed / 0x7fffffff) * n;
   }
-  private waveSeed = 20240611;
+  private fxSeed = 987654321;
+
+  private crand(n: number): number {
+    this.courseSeed = (this.courseSeed * 1103515245 + 12345) & 0x7fffffff;
+    return (this.courseSeed / 0x7fffffff) * n;
+  }
+  private courseSeed = 20240611;
+  private baseSeed = 20240611;
+  private deterministicGen = false;
+
+  /**
+   * Point the course generator at a seed (takes effect on the next reset /
+   * toTitle). Deterministic mode — the DAILY LINE — additionally derives
+   * difficulty, unlocks and hazard lead from POSITION instead of run time, so
+   * the generated course is a pure function of the seed: every player skates
+   * the same line regardless of pace.
+   */
+  setCourse(seed: number, deterministic = false) {
+    this.baseSeed = (seed & 0x7fffffff) || 1;
+    this.deterministicGen = deterministic;
+  }
+
+  /** Course-gen clock: real run time normally; position-equivalent in daily. */
+  private genTime(): number {
+    return this.deterministicGen ? this.cursorX / 430 : this.runTime;
+  }
+
+  /** Speed estimate for hazard lead — deterministic in daily mode. */
+  private genSpeed(): number {
+    return this.deterministicGen
+      ? Math.min(740, BASE_SPEED + this.genTime() * 7)
+      : this.effSpeed();
+  }
 
   private difficulty(): number {
-    // endless: difficulty rides the run clock, not position. Gentle for the
-    // first ~80s, then holds near max while speed + pacing keep ramping.
-    return Math.min(this.runTime / 80, 1);
+    // endless: difficulty rides the run clock (position-equivalent time in
+    // daily mode). Gentle for the first ~80s, then holds near max while speed
+    // + pacing keep ramping.
+    return Math.min(this.genTime() / 80, 1);
   }
 
   private zoneIndexAt(worldX: number): number {
@@ -779,11 +837,11 @@ export class SkateGameEngine {
 
   /** Extra runway before a hazard, scaled by speed so fast = more warning. */
   private lead(base: number): number {
-    return base + this.effSpeed() * 0.16;
+    return base + this.genSpeed() * 0.16;
   }
 
   private primeCourse() {
-    this.waveSeed = 20240611;
+    this.courseSeed = this.baseSeed;
     this.cursorX = 760;
     while (this.cursorX < this.px + this.W * 2.5) this.addChunk();
   }
@@ -796,6 +854,7 @@ export class SkateGameEngine {
     this.gaps = this.gaps.filter((g) => g.x1 > cull);
     this.rails = this.rails.filter((r) => r.x1 > cull);
     this.ramps = this.ramps.filter((r) => r.xLip > cull);
+    this.slopes = this.slopes.filter((s) => s.x1 > cull);
     this.loops = this.loops.filter((l) => l.x + 2 * l.r > cull);
     this.bubbles = this.bubbles.filter((b) => b.x > cull && !b.taken);
     this.letters = this.letters.filter((l) => l.x > cull && !l.taken);
@@ -815,28 +874,34 @@ export class SkateGameEngine {
     const slot = this.letterIdx % STREME_LETTERS.length;
     this.letters.push({ x, y, ch: STREME_LETTERS[slot], slot, taken: false });
     this.letterIdx = (this.letterIdx + 1) % STREME_LETTERS.length;
-    this.nextLetterAt = this.cursorX + 2400 + this.rand(800);
+    this.nextLetterAt = this.cursorX + 2400 + this.crand(800);
   }
 
   private maybePower(x: number, y: number) {
     this.chunksSincePower++;
     if (this.chunksSincePower < 7) return;
-    if (this.rand(1) < 0.55) return;
+    if (this.crand(1) < 0.55) return;
     this.chunksSincePower = 0;
     const kind: PowerKind = this.powerIdx++ % 2 === 0 ? "magnet" : "rocket";
     this.powers.push({ x, y, kind, taken: false });
   }
 
-  private addRamp(x0: number, size: "small" | "med" | "big"): Ramp {
+  private addRamp(x0: number, size: "small" | "med" | "big", vcap?: number): Ramp {
     const d = this.difficulty();
     let len: number, h: number, launch: number;
     // exaggerated size range: little kickers vs huge launch ramps
     if (size === "small") { len = 76; h = 40 + d * 10; launch = 600 + d * 60; }
     else if (size === "med") { len = 116; h = 84 + d * 16; launch = 880 + d * 90; }
     else { len = 168; h = 150 + d * 26; launch = 1180 + d * 130; }
-    const r: Ramp = { x0, xLip: x0 + len, height: h, launch };
+    const r: Ramp = { x0, xLip: x0 + len, height: h, launch, vcap };
     this.ramps.push(r);
     return r;
+  }
+
+  private addSlope(x0: number, height: number, len: number): Slope {
+    const s: Slope = { x0, x1: x0 + len, height };
+    this.slopes.push(s);
+    return s;
   }
 
   private coinLine(x: number, y: number, n: number, step = 44) {
@@ -847,9 +912,9 @@ export class SkateGameEngine {
 
   private spFlat() {
     const x = this.cursorX;
-    const len = 230 + this.rand(120);
+    const len = 230 + this.crand(120);
     this.coinLine(x + 50, 44, 6);
-    if (this.rand(1) < 0.4) this.bubbleArc(x + len / 2, 90, 80, 5, 36);
+    if (this.crand(1) < 0.4) this.bubbleArc(x + len / 2, 90, 80, 5, 36);
     this.maybeLetter(x + len / 2, 120);
     this.maybePower(x + len / 2, 150);
     this.cursorX = x + len;
@@ -857,90 +922,90 @@ export class SkateGameEngine {
 
   private spKickerAir(size: "small" | "med") {
     const x = this.cursorX;
-    const r = this.addRamp(x + 110 + this.rand(50), size);
+    const r = this.addRamp(x + 110 + this.crand(50), size);
     this.bubbleArc(r.xLip + 90, r.height + 50, 120, 5, 38);
     this.maybeLetter(r.xLip + 90, r.height + 150);
-    this.cursorX = r.xLip + 320 + this.rand(60);
+    this.cursorX = r.xLip + 320 + this.crand(60);
   }
 
   private spGap() {
     // narrow, jumpable-without-a-ramp gap; coin arc traces the jump
     const x = this.cursorX;
     const d = this.difficulty();
-    const w = 90 + d * 80 + this.rand(50);
-    const gx = x + this.lead(120) + this.rand(60);
+    const w = 90 + d * 80 + this.crand(50);
+    const gx = x + this.lead(120) + this.crand(60);
     this.gaps.push({ x0: gx, x1: gx + w });
     this.bubbleArc(gx + w / 2, 120, 70, 5, 34);
     this.maybeLetter(gx + w / 2, 170);
     this.maybePower(gx + w / 2, 200);
-    this.cursorX = gx + w + 220 + this.rand(70);
+    this.cursorX = gx + w + 220 + this.crand(70);
   }
 
   private spKickerGap() {
     // WIDE gap — always fronted by a ramp so it's clearable (solvability rule)
     const x = this.cursorX;
     const d = this.difficulty();
-    const r = this.addRamp(x + this.lead(110) + this.rand(40), "med");
-    const w = 170 + d * 200 + this.rand(70);
+    const r = this.addRamp(x + this.lead(110) + this.crand(40), "med");
+    const w = 170 + d * 200 + this.crand(70);
     const gx = r.xLip + 6;
     this.gaps.push({ x0: gx, x1: gx + w });
     this.bubbleArc(gx + w / 2, r.height + 30, 110, 6, 36);
     this.maybeLetter(gx + w / 2, r.height + 170);
-    this.cursorX = gx + w + 260 + this.rand(80);
+    this.cursorX = gx + w + 260 + this.crand(80);
   }
 
   private spRail() {
     const x = this.cursorX;
-    const len = 220 + this.rand(160);
-    const h = 66 + this.rand(22);
-    const rx = x + 130 + this.rand(60);
+    const len = 220 + this.crand(160);
+    const h = 66 + this.crand(22);
+    const rx = x + 130 + this.crand(60);
     this.rails.push({ x0: rx, x1: rx + len, height: h });
     this.coinLine(rx + 26, h + 20, 6, len / 6);
     this.maybeLetter(rx + len / 2, h + 52);
     this.maybePower(rx + len / 2, h + 90);
-    this.cursorX = rx + len + 200 + this.rand(70);
+    this.cursorX = rx + len + 200 + this.crand(70);
   }
 
   private spRailGap() {
     // a gap under a rail — grind across, or jump it from the ground
     const x = this.cursorX;
-    const len = 240 + this.rand(140);
-    const h = 64 + this.rand(20);
-    const rx = x + this.lead(110) + this.rand(50);
+    const len = 240 + this.crand(140);
+    const h = 64 + this.crand(20);
+    const rx = x + this.lead(110) + this.crand(50);
     this.rails.push({ x0: rx, x1: rx + len, height: h });
     const gx = rx + len * 0.32;
     this.gaps.push({ x0: gx, x1: gx + Math.min(len * 0.36, 140) });
     this.coinLine(rx + 26, h + 20, 6, len / 6);
     this.maybeLetter(rx + len / 2, h + 52);
-    this.cursorX = rx + len + 220 + this.rand(70);
+    this.cursorX = rx + len + 220 + this.crand(70);
   }
 
   private spKickerRail() {
     // high line: ramp launches you up to an elevated rail; ground stays clear
     const x = this.cursorX;
-    const r = this.addRamp(x + 120 + this.rand(40), "med");
+    const r = this.addRamp(x + 120 + this.crand(40), "med");
     const rx = r.xLip + 110;
-    const len = 200 + this.rand(120);
+    const len = 200 + this.crand(120);
     const railH = r.height + 58;
     this.rails.push({ x0: rx, x1: rx + len, height: railH });
     this.coinLine(rx + 20, railH + 18, 5, len / 5);
     this.maybeLetter(rx + len / 2, railH + 50);
-    this.cursorX = rx + len + 220 + this.rand(70);
+    this.cursorX = rx + len + 220 + this.crand(70);
   }
 
   private spDoubleKicker() {
     const x = this.cursorX;
-    const r1 = this.addRamp(x + 120 + this.rand(40), "small");
+    const r1 = this.addRamp(x + 120 + this.crand(40), "small");
     this.bubbleArc(r1.xLip + 70, r1.height + 40, 90, 4, 34);
     const r2 = this.addRamp(r1.xLip + 220, "small");
     this.bubbleArc(r2.xLip + 70, r2.height + 40, 90, 4, 34);
-    this.cursorX = r2.xLip + 280 + this.rand(60);
+    this.cursorX = r2.xLip + 280 + this.crand(60);
   }
 
   private spQuarter() {
     // crescendo set piece — big quarterpipe, huge air, sky-high reward
     const x = this.cursorX;
-    const r = this.addRamp(x + 140 + this.rand(40), "big");
+    const r = this.addRamp(x + 140 + this.crand(40), "big");
     this.bubbleArc(r.xLip + 100, r.height + 60, 160, 6, 40);
     this.maybeLetter(r.xLip + 100, r.height + 220);
     this.powers.push({
@@ -950,7 +1015,7 @@ export class SkateGameEngine {
       taken: false,
     });
     this.chunksSincePower = 0;
-    this.cursorX = r.xLip + 440 + this.rand(80);
+    this.cursorX = r.xLip + 440 + this.crand(80);
   }
 
   private spLoop() {
@@ -968,7 +1033,7 @@ export class SkateGameEngine {
     // "rhythm game" beat OlliOlli leans on. No gaps, just flow + coins.
     const x = this.cursorX;
     let rx = x + 110;
-    const n = 3 + Math.floor(this.rand(1.6));
+    const n = 3 + Math.floor(this.crand(1.6));
     for (let i = 0; i < n; i++) {
       const r = this.addRamp(rx, "small");
       this.bubbleArc(r.xLip + 48, r.height + 34, 64, 3, 30);
@@ -983,9 +1048,9 @@ export class SkateGameEngine {
     // landing on solid ground (a satisfying grind line, no pit risk)
     const x = this.cursorX;
     let rx = x + 130;
-    let h = 124 + this.rand(20);
+    let h = 124 + this.crand(20);
     for (let i = 0; i < 3; i++) {
-      const len = 116 + this.rand(40);
+      const len = 116 + this.crand(40);
       this.rails.push({ x0: rx, x1: rx + len, height: h });
       this.coinLine(rx + 16, h + 18, 3, len / 3);
       rx += len + 42;
@@ -995,10 +1060,62 @@ export class SkateGameEngine {
     this.cursorX = rx + 150;
   }
 
+  private spMegaRamp() {
+    // GAP CITY signature — kicker, a yawning gap, then a landing slope: clear
+    // the gap and stomp the downhill face for a HILL BOMB momentum surge
+    // (Tiny Wings / Alto: read the terrain, ride it)
+    const x = this.cursorX;
+    const d = this.difficulty();
+    const r = this.addRamp(x + this.lead(120) + this.crand(40), "med");
+    const w = 150 + d * 150 + this.crand(60);
+    const gx = r.xLip + 6;
+    this.gaps.push({ x0: gx, x1: gx + w });
+    const s = this.addSlope(gx + w, 64 + this.crand(18), 190 + this.crand(50));
+    this.bubbleArc(gx + w / 2, r.height + 40, 110, 6, 38);
+    this.maybeLetter(s.x1 + 60, 120);
+    this.cursorX = s.x1 + 240 + this.crand(70);
+  }
+
+  private spVertWall() {
+    // VERT HEIGHTS signature — a towering quarter with a raised launch ceiling
+    // (every other ramp caps lower): real hang-time for multi-flip airs, with
+    // a coin ladder climbing to a letter at the apex
+    const x = this.cursorX;
+    const r = this.addRamp(x + this.lead(130) + this.crand(40), "big", 920);
+    for (let i = 0; i < 5; i++) {
+      this.bubbles.push({
+        x: r.xLip + 70 + i * 26,
+        y: r.height + 90 + i * 44,
+        taken: false,
+      });
+    }
+    this.maybeLetter(r.xLip + 190, r.height + 260);
+    this.cursorX = r.xLip + 430 + this.crand(80);
+  }
+
+  private spFlowline() {
+    // OVERDRIVE signature — kicker → downslope cadence: launch, match the
+    // downhill, surge, repeat. Pure momentum reading, no pit risk.
+    const x = this.cursorX;
+    let cx = x + 110;
+    const n = 2 + (this.crand(1) < 0.5 ? 0 : 1);
+    for (let i = 0; i < n; i++) {
+      const r = this.addRamp(cx, "small");
+      const s = this.addSlope(
+        r.xLip + 86,
+        Math.max(34, r.height - 6),
+        150 + this.crand(40)
+      );
+      this.bubbleArc(r.xLip + 50, r.height + 36, 70, 3, 30);
+      cx = s.x1 + 120;
+    }
+    this.cursorX = cx + 120;
+  }
+
   private spRest() {
     // a forced breather after a challenge cluster — long, safe, coins to grab
     const x = this.cursorX;
-    const len = 320 + this.rand(120);
+    const len = 320 + this.crand(120);
     this.coinLine(x + 50, 44, 8, 52);
     this.maybeLetter(x + len / 2, 110);
     this.cursorX = x + len;
@@ -1020,7 +1137,7 @@ export class SkateGameEngine {
     this.cursorX = x + len + 120;
   }
 
-  private readonly HARD = new Set(["kickerGap", "railGap", "kickerRail", "quarter"]);
+  private readonly HARD = new Set(["kickerGap", "railGap", "kickerRail", "quarter", "megaRamp"]);
 
   private buildChunk(name: string, d: number) {
     switch (name) {
@@ -1036,6 +1153,9 @@ export class SkateGameEngine {
       case "loop": this.spLoop(); break;
       case "rhythm": this.spRhythm(); break;
       case "stairs": this.spStairs(); break;
+      case "megaRamp": this.spMegaRamp(); break;
+      case "vertWall": this.spVertWall(); break;
+      case "flowline": this.spFlowline(); break;
       default: this.spFlat();
     }
   }
@@ -1050,6 +1170,9 @@ export class SkateGameEngine {
       case "railGap": return t > 28;
       case "kickerRail": return t > 30;
       case "kickerGap": return t > 38;
+      case "flowline": return t > 22;
+      case "megaRamp": return t > 34;
+      case "vertWall": return t > 42;
       case "quarter": return t > 46;
       case "loop": return t > 58;
       default: return true; // flat, kickerAir, rail — always available
@@ -1066,7 +1189,7 @@ export class SkateGameEngine {
   private addChunk() {
     this.chunkCount++;
     const d = this.difficulty();
-    const t = this.runTime;
+    const t = this.genTime();
 
     // --- opening: orient to speed + teach the mechanics on safe ground ---
     if (this.chunkCount <= 2) { this.spFlat(); this.lastChunk = "flat"; return; }
@@ -1083,7 +1206,7 @@ export class SkateGameEngine {
     }
 
     // --- periodic REWARD corridor before the difficulty climbs ---
-    if (this.chunksSinceReward >= 6 && this.rand(1) < 0.6) {
+    if (this.chunksSinceReward >= 6 && this.crand(1) < 0.6) {
       this.chunksSinceReward = 0;
       this.spReward();
       this.lastChunk = "reward";
@@ -1106,7 +1229,7 @@ export class SkateGameEngine {
     if (choices.length === 0) { this.spFlat(); this.lastChunk = "flat"; return; }
 
     const total = choices.reduce((s, [, w]) => s + w, 0);
-    let r = this.rand(total);
+    let r = this.crand(total);
     let pick = choices[0][0];
     for (const [name, w] of choices) {
       if (r < w) { pick = name; break; }
@@ -1141,11 +1264,24 @@ export class SkateGameEngine {
     return r.height * t * t;
   }
 
+  private slopeAt(worldX: number): Slope | null {
+    for (const s of this.slopes) if (worldX >= s.x0 && worldX < s.x1) return s;
+    return null;
+  }
+
+  /** Eased downslope surface (steep drop-in, mellow runout) above baseline. */
+  private slopeSurface(s: Slope, worldX: number): number {
+    const t = Math.min(Math.max((worldX - s.x0) / (s.x1 - s.x0), 0), 1);
+    return s.height * (1 - t) * (1 - t);
+  }
+
   /** Ground height at a world x — ramp surface, 0 flat, or NaN over a gap. */
   private surfaceAt(worldX: number): number {
     for (const g of this.gaps) if (worldX > g.x0 && worldX < g.x1) return NaN;
     const r = this.rampAt(worldX);
     if (r) return this.rampSurface(r, worldX);
+    const s = this.slopeAt(worldX);
+    if (s) return this.slopeSurface(s, worldX);
     return 0;
   }
 
@@ -1355,9 +1491,25 @@ export class SkateGameEngine {
         this.rampUnder = null;
         this.launchFromRamp(r);
       } else {
-        this.rampUnder = null;
-        this.py = 0;
-        this.boardRot *= Math.max(0, 1 - dt * 12);
+        const slope = this.slopeAt(this.px);
+        if (slope) {
+          // bombing a downhill — gravity pulls you faster while you ride it
+          this.rampUnder = null;
+          this.py = this.slopeSurface(slope, this.px);
+          const grad =
+            (this.slopeSurface(slope, this.px + 5) -
+              this.slopeSurface(slope, this.px - 5)) /
+            10;
+          this.boardRot = -Math.atan(grad);
+          this.speed = Math.min(MAX_SPEED, this.speed + SLOPE_GRAVITY * dt);
+          if (this.rand(1) < 0.3) {
+            this.spark(this.skaterX - 8, this.groundY - this.py + 4, 1);
+          }
+        } else {
+          this.rampUnder = null;
+          this.py = 0;
+          this.boardRot *= Math.max(0, 1 - dt * 12);
+        }
       }
     } else if (this.state === "airborne") {
       if (this.coyoteT > 0) this.coyoteT = Math.max(0, this.coyoteT - dt);
@@ -1493,8 +1645,9 @@ export class SkateGameEngine {
       0,
       Math.min(1, (this.effSpeed() - BASE_SPEED) / (MAX_SPEED - BASE_SPEED))
     );
-    // cap so even the big ramps keep you on screen (height still varies the feel)
-    this.vy = Math.min(700, r.launch * (0.85 + 0.3 * norm));
+    // cap so even the big ramps keep you on screen (height still varies the
+    // feel) — vert walls carry their own raised ceiling for real hang-time
+    this.vy = Math.min(r.vcap ?? 700, r.launch * (0.85 + 0.3 * norm));
     this.boost = Math.min(BOOST_CAP, this.boost + 55); // ramps fling you forward
     this.spinV = 0;
     this.rotAccum = 0;
@@ -1577,6 +1730,16 @@ export class SkateGameEngine {
       this.cb.onCallout?.("CLOSE!", "close");
       this.boost = Math.min(BOOST_CAP, this.boost + 70);
       this.addTime(1.5); // threading a gap is exactly the kind of "great" we reward
+    }
+
+    // terrain momentum: stomping a (non-sloppy) landing onto a downslope face
+    // converts the drop into speed — the Tiny Wings slope-match made tactile
+    if (off < 0.95 && this.slopeAt(this.px)) {
+      this.speed = Math.min(MAX_SPEED, this.speed + SLOPE_BOMB_SPEED);
+      this.boost = Math.min(BOOST_CAP, this.boost + SLOPE_BOMB_BOOST);
+      this.cb.onCallout?.("HILL BOMB!", "power");
+      this.addTime(1.0);
+      this.landBurst(10, C_TEAL);
     }
   }
 
@@ -1819,6 +1982,7 @@ export class SkateGameEngine {
     this.drawSpeedLines(ctx, W);
     this.drawStreet(ctx, W, H);
     this.drawRamps(ctx);
+    this.drawSlopes(ctx);
     this.drawLoops(ctx);
     this.drawRails(ctx);
     this.drawCollectibles(ctx);
@@ -2037,6 +2201,45 @@ export class SkateGameEngine {
       ctx.shadowBlur = 12;
       ctx.fillStyle = "#ffffff";
       ctx.fillRect(xL - 5, this.groundY - r.height - 3, 7, 5);
+      ctx.shadowBlur = 0;
+    }
+  }
+
+  private drawSlopes(ctx: CanvasRenderingContext2D) {
+    for (const s of this.slopes) {
+      const x0 = this.sx(s.x0);
+      const x1 = this.sx(s.x1);
+      if (x1 < -40 || x0 > this.W + 40) continue;
+      const STEPS = 10;
+      const pts: [number, number][] = [];
+      for (let i = 0; i <= STEPS; i++) {
+        const wx = s.x0 + (s.x1 - s.x0) * (i / STEPS);
+        pts.push([this.sx(wx), this.groundY - this.slopeSurface(s, wx)]);
+      }
+      // body
+      ctx.beginPath();
+      ctx.moveTo(x0, this.groundY);
+      for (const [px, py] of pts) ctx.lineTo(px, py);
+      ctx.lineTo(x1, this.groundY);
+      ctx.closePath();
+      const rg = ctx.createLinearGradient(0, this.groundY - s.height, 0, this.groundY);
+      rg.addColorStop(0, "#4a2391");
+      rg.addColorStop(1, "#241552");
+      ctx.fillStyle = rg;
+      ctx.fill();
+      // glowing downhill face — teal (vs cyan kickers) signals "ride me down"
+      ctx.strokeStyle = C_TEAL;
+      ctx.shadowColor = C_TEAL;
+      ctx.shadowBlur = 8;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(pts[0][0], pts[0][1]);
+      for (const [px, py] of pts) ctx.lineTo(px, py);
+      ctx.stroke();
+      // bright crest cap (the drop-in edge)
+      ctx.shadowBlur = 12;
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(x0 - 2, this.groundY - s.height - 3, 7, 5);
       ctx.shadowBlur = 0;
     }
   }

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -15,12 +15,17 @@ import {
   SkateResult,
   SwipeDir,
 } from "./SkateGameEngine";
-import { buildSkateShareIntent } from "../../lib/skateShare";
+import {
+  buildDailyShareIntent,
+  buildSkateShareIntent,
+} from "../../lib/skateShare";
+import { FREE_SKATE_SEED, formatTimeLeft } from "../../lib/skateDaily";
 
 export interface SkateChallenge {
   score: number;
   by?: string;
   rank?: number;
+  day?: string; // present on DAILY LINE dares — only live while that day runs
 }
 
 interface LeaderboardEntry {
@@ -29,6 +34,7 @@ interface LeaderboardEntry {
   pfpUrl: string;
   score: number;
   combo: number;
+  rank?: number; // 1-based, present on daily "nearby" rows
 }
 
 interface LeaderboardData {
@@ -44,7 +50,34 @@ interface RankResult {
   improved: boolean;
 }
 
+interface DailyStatus {
+  day: string;
+  name: string;
+  seed: number;
+  endsAt: number;
+  attemptUsed: boolean;
+  me: { rank: number; score: number } | null;
+  streak: { count: number; best: number };
+  total: number;
+  entries: LeaderboardEntry[];
+  nearby: LeaderboardEntry[];
+  ghosts: { fid: number; username: string; samples: number[] }[];
+}
+
+interface DailySubmitResult {
+  rank: number;
+  total: number;
+  streak: { count: number; best: number };
+  alreadyPlayed: boolean;
+}
+
 type Phase = "ready" | "playing" | "over";
+type SkateMode = "free" | "daily";
+type RunKind = "free" | "practice" | "counted";
+
+// In local dev (browser, no Farcaster host) submit with the API's x-dev-fid
+// escape hatch so the whole daily flow is testable; never set in production.
+const DEV_FID = process.env.NODE_ENV === "development" ? 6841 : null;
 
 const BEST_KEY = "streme-skate-best";
 const MUTED_KEY = "streme-skate-muted";
@@ -232,7 +265,19 @@ export default function StremeSkateGame({
   const [showBoard, setShowBoard] = useState(false);
   const [board, setBoard] = useState<LeaderboardData | null>(null);
   const [boardLoading, setBoardLoading] = useState(false);
+  const [boardTab, setBoardTab] = useState<"daily" | "alltime">("daily");
   const [finishedRun, setFinishedRun] = useState<SkateResult | null>(null);
+
+  // ----- DAILY LINE: one shared seed per UTC day, one counted run each -----
+  const [mode, setMode] = useState<SkateMode>("free");
+  const modeRef = useRef<SkateMode>("free");
+  const [daily, setDaily] = useState<DailyStatus | null>(null);
+  const dailyRef = useRef<DailyStatus | null>(null);
+  const [dailyResult, setDailyResult] = useState<DailySubmitResult | null>(null);
+  const [runKind, setRunKind] = useState<RunKind>("free");
+  const runKindRef = useRef<RunKind>("free");
+  const autoDailyRef = useRef(false); // default to the daily once it loads
+  const [nowTs, setNowTs] = useState(() => Date.now()); // reset countdown tick
 
   const { isMiniAppView, isSDKLoaded, farcasterContext } = useAppFrameLogic();
   const {
@@ -249,8 +294,15 @@ export default function StremeSkateGame({
     pfpUrl?: string;
   } | null>(null);
   fcUserRef.current = farcasterContext?.user ?? null;
-  const challengeRef = useRef(challenge);
-  challengeRef.current = challenge;
+  // a DAILY LINE dare is only a live target while that day's line is open —
+  // once it rolls over, the course is different and the score isn't comparable
+  const liveChallenge =
+    challenge && (!challenge.day || !daily || challenge.day === daily.day)
+      ? challenge
+      : null;
+  const staleDailyDare = Boolean(challenge?.day && daily && !liveChallenge);
+  const challengeRef = useRef(liveChallenge);
+  challengeRef.current = liveChallenge;
 
   // --------------------------------------------------------------- sound fx
 
@@ -456,6 +508,39 @@ export default function StremeSkateGame({
     });
   }, [showToast]);
 
+  // Authenticated fetch: Quick Auth inside the mini-app, x-dev-fid in local
+  // dev so the daily flow is end-to-end testable in a plain browser.
+  const authedFetch = useCallback(
+    (url: string, init?: RequestInit): Promise<Response> | null => {
+      if (isMiniAppRef.current) return sdk.quickAuth.fetch(url, init);
+      if (DEV_FID) {
+        return fetch(url, {
+          ...init,
+          headers: {
+            ...(init?.headers as Record<string, string> | undefined),
+            "x-dev-fid": String(DEV_FID),
+          },
+        });
+      }
+      return null;
+    },
+    []
+  );
+
+  // Today's line: status + board + rival ghosts in one read
+  const loadDaily = useCallback(async () => {
+    try {
+      const fid = fcUserRef.current?.fid ?? DEV_FID ?? undefined;
+      const res = await fetch(`/api/skate/daily${fid ? `?fid=${fid}` : ""}`);
+      if (!res.ok) return;
+      const data = (await res.json()) as DailyStatus;
+      setDaily(data);
+      dailyRef.current = data;
+    } catch {
+      // daily unavailable — free skate still works
+    }
+  }, []);
+
   const handleGameOver = useCallback((result: SkateResult) => {
     setFinishedRun(result);
     setPhase("over");
@@ -473,49 +558,96 @@ export default function StremeSkateGame({
     playTone(392, 0.18, "square", 0.06, 0.12);
 
     setRankResult(null);
-    const user = fcUserRef.current;
-    if (isMiniAppRef.current && user && result.score > 0) {
+    setDailyResult(null);
+    const user =
+      fcUserRef.current ??
+      (DEV_FID ? { fid: DEV_FID, username: "dev", pfpUrl: "" } : null);
+    if (user && result.score > 0) {
       // a held Warplet becomes your leaderboard PFP too
       const pfpUrl = warpletPfpRef.current
         ? `${window.location.origin}${warpletPfpRef.current}`
         : user.pfpUrl ?? "";
-      sdk.quickAuth
-        .fetch("/api/skate/leaderboard", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            score: result.score,
-            combo: result.bestCombo,
-            username: user.username ?? "",
-            pfpUrl,
-          }),
-        })
-        .then((res) => (res.ok ? res.json() : null))
+      authedFetch("/api/skate/leaderboard", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          score: result.score,
+          combo: result.bestCombo,
+          username: user.username ?? "",
+          pfpUrl,
+        }),
+      })
+        ?.then((res) => (res.ok ? res.json() : null))
         .then((r: RankResult | null) => {
           if (r) setRankResult(r);
         })
         .catch((e) => console.error("Leaderboard submit failed:", e));
 
-      // submit this run as a ghost for others to race
       const samples = engineRef.current?.getRecording() ?? [];
-      if (samples.length >= 8) {
-        sdk.quickAuth
-          .fetch("/api/skate/ghosts", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              score: result.score,
-              username: user.username ?? "",
-              samples,
-            }),
+
+      if (modeRef.current === "daily" && runKindRef.current === "counted") {
+        // THE counted run of the day — board rank, streak, and the recording
+        // becomes a rival ghost on today's line. Lock the attempt locally
+        // right away so an instant restart can't race the in-flight submit.
+        const day = dailyRef.current?.day;
+        setDaily((prev) => {
+          const next = prev ? { ...prev, attemptUsed: true } : prev;
+          dailyRef.current = next;
+          return next;
+        });
+        authedFetch("/api/skate/daily", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            day,
+            score: result.score,
+            combo: result.bestCombo,
+            username: user.username ?? "",
+            pfpUrl,
+            samples,
+          }),
+        })
+          ?.then(async (res) => {
+            const r = (await res.json().catch(() => null)) as
+              | (DailySubmitResult & { error?: string })
+              | null;
+            if (res.ok && r) {
+              setDailyResult(r);
+              setDaily((prev) => {
+                const next = prev
+                  ? {
+                      ...prev,
+                      attemptUsed: true,
+                      me: { rank: r.rank, score: result.score },
+                      streak: r.streak,
+                      total: r.total,
+                    }
+                  : prev;
+                dailyRef.current = next;
+                return next;
+              });
+            }
+            // refresh the board + rivals either way (409 = raced a double-submit)
+            loadDaily();
           })
-          .catch((e) => console.error("Ghost submit failed:", e));
+          .catch((e) => console.error("Daily submit failed:", e));
+      } else if (modeRef.current === "free" && samples.length >= 8) {
+        // global ghosts replay on the free-skate course — only aligned runs
+        authedFetch("/api/skate/ghosts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            score: result.score,
+            username: user.username ?? "",
+            samples,
+          }),
+        })?.catch((e) => console.error("Ghost submit failed:", e));
       }
     }
     // challenge check
     const ch = challengeRef.current;
     if (ch && result.score >= ch.score) setChallengeBeaten(true);
-  }, [playTone]);
+  }, [playTone, authedFetch, loadDaily]);
 
   // keep latest callbacks in refs for the stable engine wiring
   const cbRef = useRef({
@@ -545,10 +677,20 @@ export default function StremeSkateGame({
 
     const engine = new SkateGameEngine(container, {
       onStart: () => {
-        engineRef.current?.setGhosts(
-          ghostsOnRef.current ? ghostsRef.current : []
-        );
+        // rivals on the daily are recordings of TODAY'S line (same course, so
+        // the replays align); free skate races the global ghost pool
+        const pool =
+          modeRef.current === "daily"
+            ? (dailyRef.current?.ghosts ?? []).map((g, i) => ({
+                samples: g.samples,
+                color: GHOST_TINTS[i % GHOST_TINTS.length],
+                name: g.username ? `@${g.username}` : "rival",
+              }))
+            : ghostsRef.current;
+        engineRef.current?.setGhosts(ghostsOnRef.current ? pool : []);
         engineRef.current?.setRainbow(radModeRef.current);
+        setRunKind(runKindRef.current);
+        setDailyResult(null);
         setPhase("playing");
         setScore(0);
         setCombo(null);
@@ -654,6 +796,44 @@ export default function StremeSkateGame({
     };
   }, [isSDKLoaded]);
 
+  useEffect(() => {
+    loadDaily();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSDKLoaded]);
+
+  // Point the engine at the selected course (takes effect via toTitle re-prime)
+  const applyMode = useCallback((m: SkateMode) => {
+    setMode(m);
+    modeRef.current = m;
+    const engine = engineRef.current;
+    if (!engine) return;
+    if (m === "daily" && dailyRef.current) {
+      engine.setCourse(dailyRef.current.seed, true);
+    } else {
+      engine.setCourse(FREE_SKATE_SEED, false);
+    }
+    engine.toTitle();
+  }, []);
+
+  // Once the daily loads, make it the default selection (the event), and let
+  // a daily dare link land directly on today's line.
+  useEffect(() => {
+    if (!daily || autoDailyRef.current || phase !== "ready") return;
+    autoDailyRef.current = true;
+    applyMode("daily");
+  }, [daily, phase, applyMode]);
+
+  // tick the "resets in…" countdown while the menu is up; refetch on rollover
+  useEffect(() => {
+    if (phase !== "ready") return;
+    const id = setInterval(() => {
+      setNowTs(Date.now());
+      const d = dailyRef.current;
+      if (d && Date.now() >= d.endsAt) loadDaily();
+    }, 30_000);
+    return () => clearInterval(id);
+  }, [phase, loadDaily]);
+
   // Auto-connect the Farcaster wallet in the mini-app (like the rest of the
   // app) so Warplet skaters resolve without the user tapping connect. The
   // connector attaches to the host wallet; we only nudge it once.
@@ -743,15 +923,32 @@ export default function StremeSkateGame({
     null
   );
 
+  // Every start is just "play" — on the daily, the FIRST run of the day is
+  // the counted one; anything after is an uncounted lap (no separate buttons)
+  const stampRunKind = useCallback(() => {
+    if (modeRef.current !== "daily") {
+      runKindRef.current = "free";
+      return;
+    }
+    const canSubmit = isMiniAppRef.current || Boolean(DEV_FID);
+    runKindRef.current =
+      canSubmit && dailyRef.current && !dailyRef.current.attemptUsed
+        ? "counted"
+        : "practice";
+  }, []);
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       ensureAudio();
       if (phase === "over") return;
-      if (phase === "ready") startMusic();
+      if (phase === "ready") {
+        startMusic();
+        stampRunKind();
+      }
       engineRef.current?.holdStart();
       gestureRef.current = { x: e.clientX, y: e.clientY, fired: false };
     },
-    [phase, ensureAudio, startMusic]
+    [phase, ensureAudio, startMusic, stampRunKind]
   );
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
@@ -782,7 +979,10 @@ export default function StremeSkateGame({
         e.preventDefault();
         if (e.repeat) return;
         ensureAudio();
-        if (phase === "ready") startMusic();
+        if (phase === "ready") {
+          startMusic();
+          stampRunKind();
+        }
         engine.holdStart();
       } else if (e.key === "ArrowUp" || e.key === "w") {
         engine.swipe("up");
@@ -803,16 +1003,17 @@ export default function StremeSkateGame({
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
     };
-  }, [phase, ensureAudio, startMusic]);
+  }, [phase, ensureAudio, startMusic, stampRunKind]);
 
   const handleRestart = useCallback(() => {
     const engine = engineRef.current;
     if (!engine) return;
     setIsNewBest(false);
     setChallengeBeaten(false);
+    stampRunKind();
     startMusic();
     engine.reset();
-  }, [startMusic]);
+  }, [startMusic, stampRunKind]);
 
   // back to the title menu (change skater, toggle ghosts, RAD mode, etc.)
   const handleBackToMenu = useCallback(() => {
@@ -828,8 +1029,9 @@ export default function StremeSkateGame({
   const openBoard = useCallback(async () => {
     setShowBoard(true);
     setBoardLoading(true);
+    loadDaily(); // freshen today's board + rivals alongside the all-time list
     try {
-      const fid = fcUserRef.current?.fid;
+      const fid = fcUserRef.current?.fid ?? DEV_FID ?? undefined;
       const res = await fetch(
         `/api/skate/leaderboard${fid ? `?fid=${fid}` : ""}`
       );
@@ -839,7 +1041,7 @@ export default function StremeSkateGame({
     } finally {
       setBoardLoading(false);
     }
-  }, []);
+  }, [loadDaily]);
 
   const toggleMute = useCallback(() => {
     setMuted((prev) => {
@@ -905,17 +1107,32 @@ export default function StremeSkateGame({
 
   const handleShare = useCallback(async () => {
     const username =
-      (isMiniAppView && farcasterContext?.user?.username) || undefined;
+      (isMiniAppView && farcasterContext?.user?.username) ||
+      (DEV_FID ? "dev" : undefined);
     const runScore = finishedRun?.score ?? score;
     const runCombo = finishedRun?.bestCombo ?? 0;
-    const { castText, shareUrl } = buildSkateShareIntent({
-      score: runScore,
-      combo: runCombo,
-      username,
-      rankResult,
-      challenge,
-      challengeBeaten,
-    });
+    // a counted daily run shares the DAILY LINE dare — everyone in the feed is
+    // on the same course today, so the cast is directly comparable
+    const isDailyShare =
+      mode === "daily" && daily && (dailyResult || daily.me) ? daily : null;
+    const { castText, shareUrl } = isDailyShare
+      ? buildDailyShareIntent({
+          score: isDailyShare.me?.score ?? runScore,
+          day: isDailyShare.day,
+          name: isDailyShare.name,
+          username,
+          rank: dailyResult?.rank ?? isDailyShare.me?.rank,
+          total: dailyResult?.total ?? isDailyShare.total,
+          streak: (dailyResult?.streak ?? isDailyShare.streak)?.count,
+        })
+      : buildSkateShareIntent({
+          score: runScore,
+          combo: runCombo,
+          username,
+          rankResult,
+          challenge: liveChallenge,
+          challengeBeaten,
+        });
 
     if (isMiniAppView && isSDKLoaded) {
       try {
@@ -934,9 +1151,12 @@ export default function StremeSkateGame({
   }, [
     score,
     finishedRun,
-    challenge,
+    liveChallenge,
     challengeBeaten,
     rankResult,
+    mode,
+    daily,
+    dailyResult,
     isMiniAppView,
     isSDKLoaded,
     farcasterContext,
@@ -944,11 +1164,14 @@ export default function StremeSkateGame({
 
   // ----------------------------------------------------------------- UI
 
-  const challengeLabel = challenge
-    ? `${challenge.score.toLocaleString()}${
-        challenge.by ? ` · @${challenge.by}` : ""
+  const challengeLabel = liveChallenge
+    ? `${liveChallenge.score.toLocaleString()}${
+        liveChallenge.by ? ` · @${liveChallenge.by}` : ""
       }`
     : null;
+  const canCount = (isMiniAppView && isSDKLoaded) || Boolean(DEV_FID);
+  const dailyCounted = mode === "daily" && runKind === "counted";
+  const dailyPractice = mode === "daily" && runKind === "practice";
 
   return (
     <div
@@ -1070,6 +1293,11 @@ export default function StremeSkateGame({
             {flow && (
               <span className="font-mono text-[10px] font-bold text-amber-300 animate-pulse">
                 ⚡ FLOW STATE ×2
+              </span>
+            )}
+            {dailyCounted && (
+              <span className="font-mono text-[9px] font-bold tracking-[0.14em] text-amber-200">
+                ⚡ DAILY · 1 SHOT
               </span>
             )}
           </div>
@@ -1288,9 +1516,52 @@ export default function StremeSkateGame({
             )}
           </div>
 
-          {/* stat chips */}
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            {best > 0 && (
+          {/* mode select — the DAILY LINE is the event, free skate the gym */}
+          <div
+            className="flex w-72 items-center gap-1 rounded-full border border-white/15 bg-white/5 p-1 pointer-events-auto"
+            onPointerDown={(e) => e.stopPropagation()}
+            onPointerUp={(e) => e.stopPropagation()}
+            onPointerMove={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => applyMode("daily")}
+              className={`flex-1 rounded-full px-2 py-1.5 text-xs font-black tracking-wide transition ${
+                mode === "daily"
+                  ? "bg-amber-300 text-[#0c0626]"
+                  : "text-white/60"
+              }`}
+            >
+              ⚡ DAILY LINE
+            </button>
+            <button
+              onClick={() => applyMode("free")}
+              className={`flex-1 rounded-full px-2 py-1.5 text-xs font-black tracking-wide transition ${
+                mode === "free" ? "bg-cyan-300 text-[#0c0626]" : "text-white/60"
+              }`}
+            >
+              🛹 FREE SKATE
+            </button>
+          </div>
+
+          {/* stat chips — same column width as everything else */}
+          <div className="flex w-72 flex-col items-stretch gap-1.5 text-center empty:hidden">
+            {mode === "daily" && daily && (
+              <div className="rounded-full border border-amber-300/40 bg-amber-300/10 px-3 py-1 font-mono text-xs text-amber-100">
+                {daily.name} · resets in {formatTimeLeft(daily.endsAt, nowTs)}
+              </div>
+            )}
+            {mode === "daily" && daily && daily.streak.count >= 2 && (
+              <div className="rounded-full border border-orange-300/40 bg-orange-400/10 px-3 py-1 font-mono text-xs text-orange-200">
+                🔥 {daily.streak.count}-day streak
+              </div>
+            )}
+            {mode === "daily" && daily?.attemptUsed && daily.me && (
+              <div className="rounded-full border border-cyan-300/40 bg-cyan-400/15 px-3 py-1 font-mono text-xs text-cyan-100">
+                Today: {daily.me.score.toLocaleString()} · #{daily.me.rank} of{" "}
+                {daily.total}
+              </div>
+            )}
+            {mode === "free" && best > 0 && (
               <div className="rounded-full border border-amber-300/25 bg-white/8 px-3 py-1 font-mono text-xs text-amber-200">
                 🏆 Best {best.toLocaleString()}
               </div>
@@ -1298,21 +1569,45 @@ export default function StremeSkateGame({
             {challengeLabel && (
               <div className="rounded-full border border-cyan-300/40 bg-cyan-400/15 px-3 py-1 font-mono text-xs text-cyan-100">
                 🎯 Beat {challengeLabel}
+                {liveChallenge?.day ? " today" : ""}
+              </div>
+            )}
+            {staleDailyDare && (
+              <div className="rounded-full border border-white/15 bg-white/5 px-3 py-1 font-mono text-xs text-white/60">
+                ⏰ That dare expired — fresh line today
               </div>
             )}
           </div>
 
-          {/* PLAY (visual — tapping anywhere drops you in) */}
-          <div
-            className="mt-1 inline-flex items-center gap-2 rounded-full px-10 py-3 text-xl font-black text-[#0c0626]"
-            style={{
-              background: "linear-gradient(90deg,#67e8f9,#34d399,#fbbf24)",
-              boxShadow: "0 0 34px rgba(103,232,249,0.55)",
-              animation: "skGlow 1.5s ease-in-out infinite",
-            }}
-          >
-            ▶ PLAY
-          </div>
+          {/* PLAY (visual — tapping anywhere drops you in). On the daily the
+              first run of the day counts; the pill burns amber to say so. */}
+          {(() => {
+            const countsNext =
+              mode === "daily" && !!daily && !daily.attemptUsed && canCount;
+            return (
+              <div className="flex flex-col items-center gap-1.5">
+                <div
+                  className="mt-1 flex w-72 items-center justify-center gap-2 rounded-full py-3 text-xl font-black text-[#0c0626]"
+                  style={{
+                    background: countsNext
+                      ? "linear-gradient(90deg,#fde68a,#fb923c,#ec4899)"
+                      : "linear-gradient(90deg,#67e8f9,#34d399,#fbbf24)",
+                    boxShadow: countsNext
+                      ? "0 0 34px rgba(253,230,138,0.55)"
+                      : "0 0 34px rgba(103,232,249,0.55)",
+                    animation: "skGlow 1.5s ease-in-out infinite",
+                  }}
+                >
+                  ▶ PLAY
+                </div>
+                {countsNext && (
+                  <span className="font-mono text-[10px] font-bold text-amber-200/90">
+                    ⚡ one shot a day — this run counts
+                  </span>
+                )}
+              </div>
+            );
+          })()}
 
           {/* option chips — interactive, must not start the run. Stacked. */}
           <div
@@ -1323,7 +1618,7 @@ export default function StremeSkateGame({
           >
             <button
               onClick={toggleGhosts}
-              className={`rounded-full border px-3.5 py-1.5 text-xs font-bold transition ${
+              className={`w-72 rounded-full border px-3.5 py-1.5 text-xs font-bold transition ${
                 ghostsOn
                   ? "border-cyan-300/50 bg-cyan-400/20 text-cyan-100"
                   : "border-white/15 bg-white/5 text-white/60"
@@ -1333,13 +1628,13 @@ export default function StremeSkateGame({
             </button>
             <button
               onClick={() => setShowPicker(true)}
-              className="rounded-full border border-amber-300/40 bg-amber-300/10 px-3.5 py-1.5 text-xs font-bold text-amber-100"
+              className="w-72 rounded-full border border-amber-300/40 bg-amber-300/10 px-3.5 py-1.5 text-xs font-bold text-amber-100"
             >
               {selectedWarplet ? "✨" : "🛹"} Choose your skater
             </button>
             <button
               onClick={openBoard}
-              className="rounded-full border border-cyan-300/40 bg-white/5 px-3.5 py-1.5 text-xs font-bold text-cyan-100"
+              className="w-72 rounded-full border border-cyan-300/40 bg-white/5 px-3.5 py-1.5 text-xs font-bold text-cyan-100"
             >
               🏆 Leaderboard
             </button>
@@ -1355,6 +1650,17 @@ export default function StremeSkateGame({
           onPointerDown={(e) => e.stopPropagation()}
         >
           <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-6 shadow-2xl text-center">
+            {dailyCounted && daily && (
+              <div className="mb-1 font-mono text-xs font-black tracking-[0.18em] text-amber-500">
+                ⚡ DAILY LINE · {daily.name}
+              </div>
+            )}
+            {dailyPractice && daily?.me && (
+              <div className="mb-1 font-mono text-xs font-bold tracking-[0.14em] opacity-50">
+                ⚡ TODAY&apos;S RUN: {daily.me.score.toLocaleString()} · #
+                {daily.me.rank}
+              </div>
+            )}
             <div className="text-sm font-bold uppercase tracking-widest opacity-60">
               {finishedRun.timedOut ? "⏱ Time up" : "💥 Wipeout"} ·{" "}
               {finishedRun.distance.toLocaleString()}m
@@ -1367,7 +1673,46 @@ export default function StremeSkateGame({
               <span>🏆 combo {finishedRun.bestCombo.toLocaleString()}</span>
               <span>🫧 {finishedRun.bubbles.toLocaleString()}</span>
             </div>
-            {rankResult && (
+            {dailyCounted && dailyResult && (
+              <div className="mt-2 flex flex-wrap justify-center gap-2">
+                <button
+                  className="rounded-full bg-amber-400/15 px-3 py-1 font-mono text-sm font-bold text-amber-600"
+                  onClick={openBoard}
+                >
+                  ⚡ #{dailyResult.rank} of {dailyResult.total} today
+                </button>
+                {dailyResult.streak.count >= 2 && (
+                  <span className="rounded-full bg-orange-400/15 px-3 py-1 font-mono text-sm font-bold text-orange-500">
+                    🔥 {dailyResult.streak.count}-day streak
+                  </span>
+                )}
+              </div>
+            )}
+            {dailyCounted && daily && daily.nearby.length > 0 && (
+              <div className="mt-2 rounded-lg bg-base-200 px-3 py-2 text-left">
+                <div className="mb-1 text-center font-mono text-[10px] font-bold tracking-widest opacity-50">
+                  RIVALS ON TODAY&apos;S LINE
+                </div>
+                {daily.nearby.map((e) => {
+                  const isMe = fcUserRef.current?.fid === e.fid;
+                  return (
+                    <div
+                      key={e.fid}
+                      className={`flex items-center justify-between font-mono text-xs ${
+                        isMe ? "font-bold text-primary" : "opacity-70"
+                      }`}
+                    >
+                      <span className="truncate">
+                        {e.username ? `@${e.username}` : `fid ${e.fid}`}
+                        {isMe ? " (you)" : ""}
+                      </span>
+                      <span>{e.score.toLocaleString()}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {rankResult && !dailyCounted && (
               <button
                 className="mt-1 font-mono text-sm font-semibold text-primary underline-offset-2 hover:underline"
                 onClick={openBoard}
@@ -1376,10 +1721,10 @@ export default function StremeSkateGame({
               </button>
             )}
             <div className="mt-2 text-sm opacity-70">
-              {challengeBeaten && challenge ? (
+              {challengeBeaten && liveChallenge ? (
                 <span className="font-bold text-success">
                   🏆 Challenge smashed
-                  {challenge.by ? ` — sorry @${challenge.by}` : ""}!
+                  {liveChallenge.by ? ` — sorry @${liveChallenge.by}` : ""}!
                 </span>
               ) : isNewBest ? (
                 <span className="font-bold text-success">🏆 New best run!</span>
@@ -1389,10 +1734,10 @@ export default function StremeSkateGame({
             </div>
             <div className="mt-5 flex flex-col gap-2">
               <button className="btn btn-primary w-full" onClick={handleShare}>
-                Challenge your friends
+                {dailyCounted ? "⚡ Dare the feed" : "Challenge your friends"}
               </button>
               <button className="btn btn-outline w-full" onClick={handleRestart}>
-                Drop in again
+                ▶ Play again
               </button>
               <div className="flex gap-2">
                 <button
@@ -1538,7 +1883,7 @@ export default function StremeSkateGame({
         </div>
       )}
 
-      {/* ---------- leaderboard overlay ---------- */}
+      {/* ---------- leaderboard overlay (TODAY / ALL-TIME) ---------- */}
       {showBoard && (
         <div
           className="absolute inset-0 z-20 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
@@ -1547,7 +1892,8 @@ export default function StremeSkateGame({
           <div className="w-full max-w-sm rounded-2xl bg-base-100/95 p-5 shadow-2xl">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-bold flex items-center gap-2">
-                <Trophy size={18} className="text-warning" /> Top Skaters
+                <Trophy size={18} className="text-warning" />
+                {boardTab === "daily" ? "Daily Line" : "Top Skaters"}
               </h2>
               <button
                 className="btn btn-circle btn-ghost btn-sm"
@@ -1557,57 +1903,140 @@ export default function StremeSkateGame({
                 <X size={16} />
               </button>
             </div>
-            <div className="mt-3 max-h-80 overflow-y-auto">
-              {boardLoading ? (
-                <div className="flex justify-center py-8">
-                  <span className="loading loading-spinner loading-md" />
-                </div>
-              ) : board && board.entries.length > 0 ? (
-                <ul className="flex flex-col gap-1">
-                  {board.entries.map((entry, i) => {
-                    const isMe = fcUserRef.current?.fid === entry.fid;
-                    return (
-                      <li
-                        key={entry.fid}
-                        className={`flex items-center gap-3 rounded-lg px-2 py-1.5 ${
-                          isMe ? "bg-primary/10 ring-1 ring-primary" : ""
-                        }`}
-                      >
-                        <span className="w-6 text-right font-mono text-sm opacity-60">
-                          {i + 1}
-                        </span>
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img
-                          src={entry.pfpUrl || "/icon-transparent.png"}
-                          alt=""
-                          className="w-7 h-7 rounded-full object-cover bg-base-300"
-                          onError={(e) => {
-                            (e.target as HTMLImageElement).src =
-                              "/icon-transparent.png";
-                          }}
-                        />
-                        <span className="flex-1 truncate text-sm font-medium">
-                          {entry.username
-                            ? `@${entry.username}`
-                            : `fid ${entry.fid}`}
-                        </span>
-                        <span className="font-mono text-sm font-semibold text-primary">
-                          {entry.score.toLocaleString()}
-                        </span>
-                      </li>
-                    );
-                  })}
-                </ul>
-              ) : (
-                <p className="py-8 text-center text-sm opacity-60">
-                  No skaters yet — be the first on the board!
-                </p>
-              )}
+
+            <div className="mt-2 flex gap-1 rounded-full bg-base-200 p-1">
+              <button
+                onClick={() => setBoardTab("daily")}
+                className={`flex-1 rounded-full py-1 text-xs font-bold ${
+                  boardTab === "daily" ? "bg-warning text-warning-content" : "opacity-60"
+                }`}
+              >
+                ⚡ TODAY
+              </button>
+              <button
+                onClick={() => setBoardTab("alltime")}
+                className={`flex-1 rounded-full py-1 text-xs font-bold ${
+                  boardTab === "alltime" ? "bg-primary text-primary-content" : "opacity-60"
+                }`}
+              >
+                🏆 ALL-TIME
+              </button>
             </div>
-            {board?.player && board.player.rank > board.entries.length && (
-              <div className="mt-2 rounded-lg bg-primary/10 px-3 py-2 text-center font-mono text-sm">
-                You: #{board.player.rank} · {board.player.best.toLocaleString()}
+
+            {boardTab === "daily" && daily && (
+              <div className="mt-2 text-center font-mono text-[11px] opacity-60">
+                {daily.name} · resets in {formatTimeLeft(daily.endsAt, nowTs)} ·{" "}
+                {daily.total} dropped in
               </div>
+            )}
+
+            <div className="mt-2 max-h-80 overflow-y-auto">
+              {(() => {
+                const entries =
+                  boardTab === "daily" ? daily?.entries ?? [] : board?.entries ?? [];
+                const loading = boardTab === "alltime" && boardLoading;
+                if (loading) {
+                  return (
+                    <div className="flex justify-center py-8">
+                      <span className="loading loading-spinner loading-md" />
+                    </div>
+                  );
+                }
+                if (entries.length === 0) {
+                  return (
+                    <p className="py-8 text-center text-sm opacity-60">
+                      {boardTab === "daily"
+                        ? "Nobody's dropped in yet — set today's line!"
+                        : "No skaters yet — be the first on the board!"}
+                    </p>
+                  );
+                }
+                const medal = (i: number) =>
+                  i === 0 ? "🥇" : i === 1 ? "🥈" : i === 2 ? "🥉" : `${i + 1}`;
+                const row = (entry: LeaderboardEntry, label: string) => {
+                  const isMe = fcUserRef.current?.fid === entry.fid;
+                  return (
+                    <li
+                      key={`${label}-${entry.fid}`}
+                      className={`flex items-center gap-3 rounded-lg px-2 py-1.5 ${
+                        isMe ? "bg-primary/10 ring-1 ring-primary" : ""
+                      }`}
+                    >
+                      <span className="w-6 text-right font-mono text-sm opacity-60">
+                        {label}
+                      </span>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={entry.pfpUrl || "/icon-transparent.png"}
+                        alt=""
+                        className="w-7 h-7 rounded-full object-cover bg-base-300"
+                        onError={(e) => {
+                          (e.target as HTMLImageElement).src =
+                            "/icon-transparent.png";
+                        }}
+                      />
+                      <span className="flex-1 truncate text-sm font-medium">
+                        {entry.username
+                          ? `@${entry.username}`
+                          : `fid ${entry.fid}`}
+                      </span>
+                      <span className="font-mono text-sm font-semibold text-primary">
+                        {entry.score.toLocaleString()}
+                      </span>
+                    </li>
+                  );
+                };
+                const nearby =
+                  boardTab === "daily" && daily?.me
+                    ? daily.nearby.filter(
+                        (e) =>
+                          (e.rank ?? 0) > entries.length &&
+                          !entries.some((t) => t.fid === e.fid)
+                      )
+                    : [];
+                return (
+                  <ul className="flex flex-col gap-1">
+                    {entries.map((e, i) => row(e, medal(i)))}
+                    {nearby.length > 0 && (
+                      <>
+                        <li className="py-0.5 text-center font-mono text-xs opacity-40">
+                          ···
+                        </li>
+                        {nearby.map((e) => row(e, String(e.rank)))}
+                      </>
+                    )}
+                  </ul>
+                );
+              })()}
+            </div>
+
+            {boardTab === "alltime" &&
+              board?.player &&
+              board.player.rank > (board?.entries.length ?? 0) && (
+                <div className="mt-2 rounded-lg bg-primary/10 px-3 py-2 text-center font-mono text-sm">
+                  You: #{board.player.rank} ·{" "}
+                  {board.player.best.toLocaleString()}
+                </div>
+              )}
+            {boardTab === "daily" && daily?.me && (
+              <div className="mt-2 flex items-center justify-between rounded-lg bg-warning/10 px-3 py-2 font-mono text-sm">
+                <span>
+                  You: #{daily.me.rank} · {daily.me.score.toLocaleString()}
+                </span>
+                {daily.streak.count >= 2 && (
+                  <span className="text-orange-500">
+                    🔥 {daily.streak.count}d
+                  </span>
+                )}
+              </div>
+            )}
+            {boardTab === "daily" && daily?.me && (
+              <button
+                className="btn btn-warning btn-sm mt-2 w-full font-bold"
+                onClick={handleShare}
+              >
+                ⚡ Dare the feed with your rank
+              </button>
             )}
             {!isMiniAppView && (
               <p className="mt-3 text-center text-xs opacity-60">

--- a/src/lib/skateDaily.ts
+++ b/src/lib/skateDaily.ts
@@ -1,0 +1,75 @@
+// Shared (client + server + OG card) helpers for the DAILY LINE — the
+// date-keyed, fixed-seed daily run. Everything here is a pure function of the
+// UTC date, so every player, the API, and the share card all agree on which
+// day it is, what its course seed is, and what the line is called.
+
+/** The fixed seed free skate has always used — kept so ghosts stay aligned. */
+export const FREE_SKATE_SEED = 20240611;
+
+/** UTC day key, e.g. "2026-06-12". The line resets at midnight UTC. */
+export function dailyKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export function isDailyKey(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+
+/** 31-bit course seed from the day key (FNV-1a) — feeds the engine RNG. */
+export function dailySeed(key: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    h ^= key.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 1) || 1; // 31-bit, never zero
+}
+
+// One name per weekday — the watercooler handle for today's line ("did you
+// run THURSDAY THRASHER yet?"), stable for everyone in every timezone.
+const LINE_NAMES = [
+  "SUNDAY SHRED",
+  "MONDAY MELTDOWN",
+  "TUESDAY TECHSLIDE",
+  "WEDNESDAY WHIPLASH",
+  "THURSDAY THRASHER",
+  "FRIDAY FAKIE",
+  "SATURDAY SLAPPY",
+];
+
+export function dailyName(key: string): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  const day = d.getUTCDay();
+  return Number.isFinite(day) ? LINE_NAMES[day] : "DAILY LINE";
+}
+
+/** Epoch ms when this day's line closes (next midnight UTC). */
+export function dailyEndsAt(key: string): number {
+  return new Date(`${key}T00:00:00Z`).getTime() + 24 * 3600 * 1000;
+}
+
+export function prevDailyKey(key: string): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+/** "JUN 12" — compact date label for cards and headers. */
+export function formatDailyDate(key: string): string {
+  const d = new Date(`${key}T00:00:00Z`);
+  return d
+    .toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    })
+    .toUpperCase();
+}
+
+/** "7h 12m" until the line resets (clamped at 0). */
+export function formatTimeLeft(endsAt: number, now: number = Date.now()): string {
+  const ms = Math.max(0, endsAt - now);
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}

--- a/src/lib/skateDailyBoard.ts
+++ b/src/lib/skateDailyBoard.ts
@@ -1,0 +1,376 @@
+import { Redis } from "@upstash/redis";
+import { prevDailyKey } from "./skateDaily";
+
+// DAILY LINE storage — a day-keyed leaderboard where each player gets exactly
+// ONE counted run (board membership IS the used attempt), plus play streaks
+// and the run recordings ("rival ghosts") for racing on the same day's course.
+// Mirrors src/lib/skateLeaderboard.ts: Redis when KV env vars exist, otherwise
+// an in-memory fallback; dev writes are namespaced away from production.
+
+export interface DailyEntry {
+  fid: number;
+  username: string;
+  pfpUrl: string;
+  score: number;
+  combo: number;
+  updatedAt: number;
+  rank?: number; // 1-based, set on `nearby` entries (they sit off the top list)
+}
+
+export interface DailyStreak {
+  count: number;
+  best: number;
+}
+
+export interface DailySubmitResult {
+  rank: number; // 1-based
+  total: number;
+  streak: DailyStreak;
+  alreadyPlayed: boolean;
+}
+
+export interface DailyGhostRecord {
+  fid: number;
+  username: string;
+  score: number;
+  samples: number[]; // flat [px,py] pairs, sampled every 0.15s by the engine
+}
+
+export interface DailyBoardData {
+  attemptUsed: boolean;
+  me: { rank: number; score: number } | null;
+  streak: DailyStreak;
+  total: number;
+  entries: DailyEntry[];
+  nearby: DailyEntry[]; // micro-leaderboard around the player (when off the top list)
+  ghosts: DailyGhostRecord[]; // rivals to race: leader + the players just above you
+}
+
+const useRedis = process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN;
+const redis = useRedis
+  ? new Redis({
+      url: process.env.KV_REST_API_URL!,
+      token: process.env.KV_REST_API_TOKEN!,
+    })
+  : null;
+
+const ENV_SUFFIX = process.env.NODE_ENV === "production" ? "" : ":dev";
+const boardKey = (day: string) => `streme-skate:daily:${day}:board${ENV_SUFFIX}`;
+const playerKey = (day: string, fid: number) =>
+  `streme-skate:daily:${day}:player:${fid}${ENV_SUFFIX}`;
+const ghostKey = (day: string, fid: number) =>
+  `streme-skate:daily:${day}:ghost:${fid}${ENV_SUFFIX}`;
+const streakKey = (fid: number) => `streme-skate:streak:${fid}${ENV_SUFFIX}`;
+
+const BOARD_TTL = 35 * 24 * 3600; // keep past lines around for ~a month
+const GHOST_TTL = 3 * 24 * 3600; // recordings are only raced on their own day
+const MAX_SAMPLES = 1400;
+const TOP_N = 10;
+
+// ---------------------------------------------------------------- fallbacks
+
+const localBoards = new Map<string, Map<number, DailyEntry>>();
+const localGhosts = new Map<string, Map<number, DailyGhostRecord>>();
+const localStreaks = new Map<number, DailyStreak & { lastDay: string }>();
+
+function localBoard(day: string): Map<number, DailyEntry> {
+  let b = localBoards.get(day);
+  if (!b) {
+    b = new Map();
+    localBoards.set(day, b);
+  }
+  return b;
+}
+
+function sanitizeSamples(samples: number[]): number[] {
+  return samples
+    .slice(0, MAX_SAMPLES)
+    .map((n) => (Number.isFinite(n) ? Math.round(n) : 0));
+}
+
+// ------------------------------------------------------------------ streaks
+
+async function bumpStreak(fid: number, day: string): Promise<DailyStreak> {
+  const yesterday = prevDailyKey(day);
+  if (redis) {
+    const cur = await redis.hgetall<Record<string, string | number>>(
+      streakKey(fid)
+    );
+    const lastDay = String(cur?.lastDay ?? "");
+    let count = Number(cur?.count ?? 0);
+    const best = Number(cur?.best ?? 0);
+    if (lastDay === day) return { count, best };
+    count = lastDay === yesterday ? count + 1 : 1;
+    const nextBest = Math.max(best, count);
+    await redis.hset(streakKey(fid), { count, best: nextBest, lastDay: day });
+    return { count, best: nextBest };
+  }
+  const cur = localStreaks.get(fid);
+  if (cur?.lastDay === day) return { count: cur.count, best: cur.best };
+  const count = cur?.lastDay === yesterday ? cur.count + 1 : 1;
+  const best = Math.max(cur?.best ?? 0, count);
+  localStreaks.set(fid, { count, best, lastDay: day });
+  return { count, best };
+}
+
+async function getStreak(fid: number): Promise<DailyStreak> {
+  if (redis) {
+    const cur = await redis.hgetall<Record<string, string | number>>(
+      streakKey(fid)
+    );
+    return { count: Number(cur?.count ?? 0), best: Number(cur?.best ?? 0) };
+  }
+  const cur = localStreaks.get(fid);
+  return { count: cur?.count ?? 0, best: cur?.best ?? 0 };
+}
+
+// ------------------------------------------------------------------- submit
+
+/**
+ * Record the player's ONE counted run for the day. Board membership is the
+ * attempt flag: a second submit returns alreadyPlayed without overwriting.
+ */
+export async function submitDailyRun(
+  day: string,
+  entry: Omit<DailyEntry, "updatedAt">,
+  samples: number[]
+): Promise<DailySubmitResult> {
+  const now = Date.now();
+  const ghost: DailyGhostRecord = {
+    fid: entry.fid,
+    username: entry.username,
+    score: entry.score,
+    samples: sanitizeSamples(samples),
+  };
+
+  if (redis) {
+    const existing = await redis.zscore(boardKey(day), String(entry.fid));
+    if (existing !== null) {
+      const [rank, total, streak] = await Promise.all([
+        redis.zrevrank(boardKey(day), String(entry.fid)),
+        redis.zcard(boardKey(day)),
+        getStreak(entry.fid),
+      ]);
+      return { rank: (rank ?? 0) + 1, total, streak, alreadyPlayed: true };
+    }
+    await redis.zadd(boardKey(day), {
+      score: entry.score,
+      member: String(entry.fid),
+    });
+    await Promise.all([
+      redis.expire(boardKey(day), BOARD_TTL),
+      redis.hset(playerKey(day, entry.fid), { ...entry, updatedAt: now }),
+      redis.expire(playerKey(day, entry.fid), BOARD_TTL),
+      ghost.samples.length >= 8
+        ? redis.set(ghostKey(day, entry.fid), JSON.stringify(ghost), {
+            ex: GHOST_TTL,
+          })
+        : Promise.resolve(),
+    ]);
+    const [rank, total, streak] = await Promise.all([
+      redis.zrevrank(boardKey(day), String(entry.fid)),
+      redis.zcard(boardKey(day)),
+      bumpStreak(entry.fid, day),
+    ]);
+    return { rank: (rank ?? 0) + 1, total, streak, alreadyPlayed: false };
+  }
+
+  const board = localBoard(day);
+  if (board.has(entry.fid)) {
+    const sorted = [...board.values()].sort((a, b) => b.score - a.score);
+    return {
+      rank: sorted.findIndex((e) => e.fid === entry.fid) + 1,
+      total: sorted.length,
+      streak: await getStreak(entry.fid),
+      alreadyPlayed: true,
+    };
+  }
+  board.set(entry.fid, { ...entry, updatedAt: now });
+  if (ghost.samples.length >= 8) {
+    let g = localGhosts.get(day);
+    if (!g) {
+      g = new Map();
+      localGhosts.set(day, g);
+    }
+    g.set(entry.fid, ghost);
+  }
+  const streak = await bumpStreak(entry.fid, day);
+  const sorted = [...board.values()].sort((a, b) => b.score - a.score);
+  return {
+    rank: sorted.findIndex((e) => e.fid === entry.fid) + 1,
+    total: sorted.length,
+    streak,
+    alreadyPlayed: false,
+  };
+}
+
+// --------------------------------------------------------------------- read
+
+function entryFromRow(
+  fid: number,
+  score: number,
+  row: Record<string, unknown> | null
+): DailyEntry {
+  return {
+    fid,
+    username: String(row?.username ?? ""),
+    pfpUrl: String(row?.pfpUrl ?? ""),
+    score,
+    combo: Number(row?.combo ?? 0),
+    updatedAt: Number(row?.updatedAt ?? 0),
+  };
+}
+
+/**
+ * Everything the client needs about today's line in one read: the top of the
+ * board, the player's rank + a micro-leaderboard around them (proximal
+ * comparison beats a distant global rank), their streak, and rival ghosts —
+ * the leader plus the players ranked just above them (a closable gap).
+ */
+export async function getDailyBoard(
+  day: string,
+  fid?: number
+): Promise<DailyBoardData> {
+  if (redis) {
+    const ranked = (await redis.zrange<(string | number)[]>(
+      boardKey(day),
+      0,
+      TOP_N - 1,
+      { rev: true, withScores: true }
+    )) as (string | number)[];
+    const top: { fid: number; score: number }[] = [];
+    for (let i = 0; i < ranked.length; i += 2) {
+      top.push({ fid: Number(ranked[i]), score: Number(ranked[i + 1]) });
+    }
+
+    const total = await redis.zcard(boardKey(day));
+    let me: { rank: number; score: number } | null = null;
+    const nearbyMembers: { fid: number; score: number; rank: number }[] = [];
+    if (fid) {
+      const [rank, score] = await Promise.all([
+        redis.zrevrank(boardKey(day), String(fid)),
+        redis.zscore(boardKey(day), String(fid)),
+      ]);
+      if (rank !== null && score !== null) {
+        me = { rank: rank + 1, score: Number(score) };
+        if (me.rank > TOP_N) {
+          const start = Math.max(0, rank - 2);
+          const around = (await redis.zrange<(string | number)[]>(
+            boardKey(day),
+            start,
+            rank + 2,
+            { rev: true, withScores: true }
+          )) as (string | number)[];
+          for (let i = 0; i < around.length; i += 2) {
+            nearbyMembers.push({
+              fid: Number(around[i]),
+              score: Number(around[i + 1]),
+              rank: start + i / 2 + 1,
+            });
+          }
+        }
+      }
+    }
+
+    // rivals to race: the leader + up to two players immediately above you
+    let rivalFids: number[] = top.slice(0, 4).map((m) => m.fid);
+    if (me && me.rank > 3) {
+      const above = (await redis.zrange<string[]>(
+        boardKey(day),
+        Math.max(0, me.rank - 3),
+        me.rank - 2,
+        { rev: true }
+      )) as string[];
+      rivalFids = [top[0]?.fid, ...above.map(Number)].filter(
+        (f): f is number => Number.isFinite(f)
+      );
+    }
+    rivalFids = [...new Set(rivalFids)].filter((f) => f !== fid).slice(0, 4);
+
+    const needProfiles = [...top, ...nearbyMembers];
+    const profiles = new Map<number, Record<string, unknown> | null>();
+    if (needProfiles.length > 0) {
+      const pipeline = redis.pipeline();
+      for (const m of needProfiles) pipeline.hgetall(playerKey(day, m.fid));
+      const rows = await pipeline.exec<(Record<string, unknown> | null)[]>();
+      needProfiles.forEach((m, i) => profiles.set(m.fid, rows[i] ?? null));
+    }
+    const entries = top.map((m) =>
+      entryFromRow(m.fid, m.score, profiles.get(m.fid) ?? null)
+    );
+    const nearby = nearbyMembers.map((m) => ({
+      ...entryFromRow(m.fid, m.score, profiles.get(m.fid) ?? null),
+      rank: m.rank,
+    }));
+
+    const ghosts: DailyGhostRecord[] = [];
+    if (rivalFids.length > 0) {
+      const rows = await Promise.all(
+        rivalFids.map((f) => redis.get(ghostKey(day, f)))
+      );
+      for (const row of rows) {
+        if (!row) continue;
+        try {
+          const rec = typeof row === "string" ? JSON.parse(row) : row;
+          if (rec && Array.isArray(rec.samples)) {
+            ghosts.push(rec as DailyGhostRecord);
+          }
+        } catch {
+          // skip malformed
+        }
+      }
+    }
+
+    return {
+      attemptUsed: me !== null,
+      me,
+      streak: fid ? await getStreak(fid) : { count: 0, best: 0 },
+      total,
+      entries,
+      nearby,
+      ghosts,
+    };
+  }
+
+  const board = localBoard(day);
+  const sorted = [...board.values()].sort((a, b) => b.score - a.score);
+  const entries = sorted.slice(0, TOP_N);
+  let me: { rank: number; score: number } | null = null;
+  let nearby: DailyEntry[] = [];
+  if (fid) {
+    const idx = sorted.findIndex((e) => e.fid === fid);
+    if (idx >= 0) {
+      me = { rank: idx + 1, score: sorted[idx].score };
+      if (me.rank > TOP_N) {
+        const start = Math.max(0, idx - 2);
+        nearby = sorted
+          .slice(start, idx + 3)
+          .map((e, i) => ({ ...e, rank: start + i + 1 }));
+      }
+    }
+  }
+  const ghostPool = localGhosts.get(day);
+  let rivalFids = sorted.slice(0, 4).map((e) => e.fid);
+  if (me && me.rank > 3) {
+    rivalFids = [
+      sorted[0].fid,
+      ...sorted.slice(Math.max(0, me.rank - 3), me.rank - 1).map((e) => e.fid),
+    ];
+  }
+  const ghosts = [...new Set(rivalFids)]
+    .filter((f) => f !== fid)
+    .slice(0, 4)
+    .map((f) => ghostPool?.get(f))
+    .filter((g): g is DailyGhostRecord => Boolean(g));
+
+  return {
+    attemptUsed: me !== null,
+    me,
+    streak: fid ? await getStreak(fid) : { count: 0, best: 0 },
+    total: sorted.length,
+    entries,
+    nearby,
+    ghosts,
+  };
+}
+

--- a/src/lib/skateShare.ts
+++ b/src/lib/skateShare.ts
@@ -2,6 +2,7 @@ export interface SkateChallenge {
   score: number;
   by?: string;
   rank?: number;
+  day?: string; // a DAILY LINE dare — only live while that day's line is open
 }
 
 export interface SkateRankResult {
@@ -95,5 +96,51 @@ export function buildSkateShareIntent({
   return {
     shareUrl,
     castText: `${opener}\n\nThink you can beat my line?\n\n${shareUrl}`,
+  };
+}
+
+interface BuildDailyShareInput {
+  score: number;
+  day: string; // UTC day key, e.g. "2026-06-12"
+  name: string; // the line's name, e.g. "THURSDAY THRASHER"
+  username?: string;
+  rank?: number;
+  total?: number;
+  streak?: number;
+  baseShareUrl?: string;
+}
+
+/**
+ * Share intent for a counted DAILY LINE run. Unlike the free-skate card this
+ * names the day's line — everyone in the feed is on the SAME course, so the
+ * cast is a direct, comparable dare (the Wordle property), not an announcement.
+ */
+export function buildDailyShareIntent({
+  score,
+  day,
+  name,
+  username,
+  rank,
+  total,
+  streak,
+  baseShareUrl = SKATE_SHARE_URL,
+}: BuildDailyShareInput): SkateShareIntent {
+  const runScore = normalizedScore(score);
+  const by = normalizedUsername(username);
+
+  let opener = `⚡ DAILY LINE · ${name}: ${runScore.toLocaleString()}`;
+  if (rank && total) opener += ` — #${rank} of ${total}`;
+  opener += " 🛹";
+  if (streak && streak >= 2) opener += `\n🔥 ${streak}-day streak`;
+
+  const params = new URLSearchParams({ d: day, s: String(runScore) });
+  if (by) params.set("by", by);
+  if (rank) params.set("r", String(rank));
+  if (streak && streak >= 2) params.set("st", String(streak));
+
+  const shareUrl = `${baseShareUrl}?${params.toString()}`;
+  return {
+    shareUrl,
+    castText: `${opener}\n\nSame line for everyone, one counted shot a day. Beat me before it resets.\n\n${shareUrl}`,
   };
 }


### PR DESCRIPTION
## What

A daily mode for Streme Skate built to make the Farcaster feed part of the game loop, plus terrain depth so zones play differently — not just look different.

**⚡ Daily Line**
- One fixed-seed course per UTC day, named per weekday (FRIDAY FAKIE, SATURDAY SLAPPY, …). Everyone skates the **same line**.
- Your **first run of the day counts** — it submits to the day's board, starts/extends your 🔥 streak, and its recording becomes a rival ghost. Later runs that day just play, uncounted (the menu pill burns amber with "⚡ one shot a day — this run counts" while your shot is live).
- **Rival ghosts**: you race the day's leader plus the players ranked just above you — same course, so replays line up with the terrain.

**Social layer**
- Leaderboard overlay gets **TODAY / ALL-TIME** tabs: medals, reset countdown, "N dropped in", your row, streak chip, and a micro-leaderboard around your rank when you're off the top 10.
- Daily share casts name the line and rank ("Same line for everyone, one counted shot a day. Beat me before it resets.") with a day-stamped link; the OG card gets a DAILY LINE banner + rank/streak chips. Dare links expire when the day rolls over.

**Engine depth**
- **Course RNG split from FX RNG** — particle spawns could previously perturb course generation. A seed now always lays the identical line (also makes ghost playback honest). In daily mode, difficulty/unlocks/hazard-lead derive from *position* instead of run time, so the course is a pure function of the seed regardless of pace. Free skate is unchanged.
- **Terrain momentum**: landing slopes — ride them for gravity speed, stomp a clean landing onto one for a **HILL BOMB!** surge.
- **Zone signatures**: GAP CITY mega-ramps (kicker → gap → landing slope), OVERDRIVE flowlines (kicker→slope rhythm), VERT HEIGHTS vert walls with a raised launch ceiling for multi-flip hangtime.

## Server

`/api/skate/daily` (GET status+board+ghosts in one read / POST counted run). Day-keyed Redis boards where **membership is the used attempt** (second submit 409s, never overwrites), per-fid streak hashes, ghost recordings with day-scoped TTL, 10-minute midnight-rollover grace. In-memory fallback for local dev (note: local `.env.local` has empty KV creds, so dev uses the fallback; prod Vercel KV unaffected).

## Verified

- Same-seed re-prime → byte-identical course; signature pieces spawn in their zones (engine-level sweep).
- Full counted flow in preview: play → submit → "⚡ #1 of N today" + streak → attempt locks → menu shows "Today: score · #rank"; later laps uncounted with the counted score shown for context.
- Duplicate-submit guard (409), share cast text + day-stamped URL, OG card render, challenge-page metadata, mobile layout, TODAY/ALL-TIME tabs.
- `typecheck` / `lint` / `build` clean; new `__tests__/lib/skateDaily.test.ts` (6 tests) passing.

Worth a real-device pass in the Farcaster client for the Quick Auth submit path (preview exercises the dev-auth fallback).