### PR TITLE
feat(skate): unlimited daily tries — best score holds the board

### DIFF
--- a/src/app/api/skate/daily/route.ts
+++ b/src/app/api/skate/daily/route.ts
@@ -135,10 +135,12 @@ export async function POST(request: NextRequest) {
       { fid, username, pfpUrl, score, combo, flair },
       samples
     );
-    return NextResponse.json(
-      { day: claimedDay, name: dailyName(claimedDay), ...result, flair },
-      { status: result.alreadyPlayed ? 409 : 200 }
-    );
+    return NextResponse.json({
+      day: claimedDay,
+      name: dailyName(claimedDay),
+      ...result,
+      flair,
+    });
   } catch (error) {
     console.error("Skate daily POST error:", error);
     return NextResponse.json(

--- a/src/app/api/skate/image/route.tsx
+++ b/src/app/api/skate/image/route.tsx
@@ -160,7 +160,7 @@ export async function GET(request: NextRequest) {
                   }}
                 >
                   {day
-                    ? `${by ? `@${by}` : "Someone"} dares you — one shot a day`
+                    ? `${by ? `@${by}` : "Someone"} dares you — best score today wins`
                     : by
                     ? `@${by} dares you to beat it`
                     : "Can you beat this line?"}

--- a/src/app/skate/page.tsx
+++ b/src/app/skate/page.tsx
@@ -67,7 +67,7 @@ export async function generateMetadata({
           challenge.by ? `@${challenge.by}` : "Someone"
         } scored ${challenge.score.toLocaleString()} on the ${dailyName(
           challenge.day
-        )} daily line. Same course for everyone, one counted shot a day — beat it before it resets.`
+        )} daily line. Same course for everyone, run it all day — best score holds. Beat it before it resets.`
       : `Someone${
           challenge.by ? ` (@${challenge.by})` : ""
         } scored ${challenge.score.toLocaleString()} in Streme Skate. Think you can beat it?`

--- a/src/components/skate/StremeSkateGame.tsx
+++ b/src/components/skate/StremeSkateGame.tsx
@@ -86,7 +86,7 @@ interface DailyStatus {
   name: string;
   seed: number;
   endsAt: number;
-  attemptUsed: boolean;
+  played: boolean;
   me: { rank: number; score: number } | null;
   streak: { count: number; best: number };
   total: number;
@@ -104,7 +104,8 @@ interface DailySubmitResult {
   rank: number;
   total: number;
   streak: { count: number; best: number };
-  alreadyPlayed: boolean;
+  improved: boolean;
+  best: number;
   flair?: FlairTier | null;
 }
 
@@ -311,7 +312,7 @@ export default function StremeSkateGame({
   const [boardTab, setBoardTab] = useState<"daily" | "alltime">("daily");
   const [finishedRun, setFinishedRun] = useState<SkateResult | null>(null);
 
-  // ----- DAILY LINE: one shared seed per UTC day, one counted run each -----
+  // ----- DAILY LINE: one shared seed per UTC day, unlimited runs, best holds -----
   const [mode, setMode] = useState<SkateMode>("free");
   const modeRef = useRef<SkateMode>("free");
   const [daily, setDaily] = useState<DailyStatus | null>(null);
@@ -629,15 +630,10 @@ export default function StremeSkateGame({
       const samples = engineRef.current?.getRecording() ?? [];
 
       if (modeRef.current === "daily" && runKindRef.current === "counted") {
-        // THE counted run of the day — board rank, streak, and the recording
-        // becomes a rival ghost on today's line. Lock the attempt locally
-        // right away so an instant restart can't race the in-flight submit.
+        // a counted run on today's line — unlimited tries within the 24h
+        // window, your BEST score holds the board rank and its recording
+        // becomes the rival ghost. The server keeps-best; we mirror that below.
         const day = dailyRef.current?.day;
-        setDaily((prev) => {
-          const next = prev ? { ...prev, attemptUsed: true } : prev;
-          dailyRef.current = next;
-          return next;
-        });
         authedFetch("/api/skate/daily", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -660,8 +656,8 @@ export default function StremeSkateGame({
                 const next = prev
                   ? {
                       ...prev,
-                      attemptUsed: true,
-                      me: { rank: r.rank, score: result.score },
+                      played: true,
+                      me: { rank: r.rank, score: r.best },
                       streak: r.streak,
                       total: r.total,
                     }
@@ -670,7 +666,7 @@ export default function StremeSkateGame({
                 return next;
               });
             }
-            // refresh the board + rivals either way (409 = raced a double-submit)
+            // refresh the board + rivals (picks up other players' new bests)
             loadDaily();
           })
           .catch((e) => console.error("Daily submit failed:", e));
@@ -971,8 +967,8 @@ export default function StremeSkateGame({
     null
   );
 
-  // Every start is just "play" — on the daily, the FIRST run of the day is
-  // the counted one; anything after is an uncounted lap (no separate buttons)
+  // Every start is just "play" — on the daily, every run counts (unlimited
+  // tries; your best holds the board). "practice" only when we can't submit.
   const stampRunKind = useCallback(() => {
     if (modeRef.current !== "daily") {
       runKindRef.current = "free";
@@ -980,9 +976,7 @@ export default function StremeSkateGame({
     }
     const canSubmit = isMiniAppRef.current || Boolean(DEV_FID);
     runKindRef.current =
-      canSubmit && dailyRef.current && !dailyRef.current.attemptUsed
-        ? "counted"
-        : "practice";
+      canSubmit && dailyRef.current ? "counted" : "practice";
   }, []);
 
   const handlePointerDown = useCallback(
@@ -1615,10 +1609,10 @@ export default function StremeSkateGame({
                 </span>
               </div>
             )}
-            {mode === "daily" && daily?.attemptUsed && daily.me && (
+            {mode === "daily" && daily?.me && (
               <div className="flex items-center justify-center gap-3 rounded-full border border-cyan-300/40 bg-cyan-400/15 px-3 py-1 text-xs text-cyan-100">
                 <span>
-                  Today <span className="font-bold">#{daily.me.rank}</span>
+                  Best <span className="font-bold">#{daily.me.rank}</span>
                   <span className="opacity-70"> of {daily.total}</span>
                 </span>
                 <span className="font-mono font-semibold">
@@ -1633,7 +1627,7 @@ export default function StremeSkateGame({
             )}
             {mode === "daily" &&
               daily &&
-              !daily.attemptUsed &&
+              !daily.me &&
               daily.streak.count >= 2 && (
                 <div className="inline-flex items-center justify-center gap-1 rounded-full border border-orange-300/40 bg-orange-400/10 px-3 py-1 text-xs font-bold text-orange-200">
                   <Flame size={12} /> {daily.streak.count}-day streak
@@ -1660,11 +1654,10 @@ export default function StremeSkateGame({
             )}
           </div>
 
-          {/* PLAY (visual — tapping anywhere drops you in). On the daily the
-              first run of the day counts; the pill burns amber to say so. */}
+          {/* PLAY (visual — tapping anywhere drops you in). On the daily every
+              run counts toward your best; the pill burns amber to say so. */}
           {(() => {
-            const countsNext =
-              mode === "daily" && !!daily && !daily.attemptUsed && canCount;
+            const countsNext = mode === "daily" && !!daily && canCount;
             return (
               <div className="flex flex-col items-center gap-1.5">
                 <div
@@ -1683,7 +1676,10 @@ export default function StremeSkateGame({
                 </div>
                 {countsNext && (
                   <span className="inline-flex items-center gap-1 text-[10px] font-bold text-amber-200/90">
-                    <Zap size={11} /> one shot a day — this run counts
+                    <Zap size={11} />{" "}
+                    {daily?.me
+                      ? "beat your best — every run counts today"
+                      : "every run counts — best holds the board"}
                   </span>
                 )}
               </div>
@@ -1839,9 +1835,23 @@ export default function StremeSkateGame({
                 board
               </button>
             )}
+            {dailyCounted && dailyResult && (
+              <div className="mt-2 text-xs opacity-60">
+                {dailyResult.improved ? (
+                  <span className="font-bold text-success">
+                    New daily best — run it back to climb higher
+                  </span>
+                ) : (
+                  <span>
+                    Didn&apos;t top today&apos;s best (
+                    {dailyResult.best.toLocaleString()}) — try again
+                  </span>
+                )}
+              </div>
+            )}
             {dailyPractice && daily?.me && (
               <div className="mt-2 text-xs opacity-50">
-                Practice run — your counted score today is{" "}
+                Practice run — your best today is{" "}
                 {daily.me.score.toLocaleString()} (#{daily.me.rank})
               </div>
             )}

--- a/src/lib/skateDailyBoard.ts
+++ b/src/lib/skateDailyBoard.ts
@@ -2,9 +2,10 @@ import { Redis } from "@upstash/redis";
 import { prevDailyKey } from "./skateDaily";
 import { FlairTier, isFlairTier } from "./skateFlair";
 
-// DAILY LINE storage — a day-keyed leaderboard where each player gets exactly
-// ONE counted run (board membership IS the used attempt), plus play streaks
-// and the run recordings ("rival ghosts") for racing on the same day's course.
+// DAILY LINE storage — a day-keyed leaderboard where each player may run the
+// course as many times as they like within the 24h window and their BEST score
+// is what stands on the board, plus play streaks and the run recordings
+// ("rival ghosts" — the recording of your best run) for racing today's course.
 // Mirrors src/lib/skateLeaderboard.ts: Redis when KV env vars exist, otherwise
 // an in-memory fallback; dev writes are namespaced away from production.
 
@@ -28,7 +29,8 @@ export interface DailySubmitResult {
   rank: number; // 1-based
   total: number;
   streak: DailyStreak;
-  alreadyPlayed: boolean;
+  improved: boolean; // did this run beat your previous best today?
+  best: number; // your best score now standing on today's board
 }
 
 export interface DailyGhostRecord {
@@ -40,7 +42,7 @@ export interface DailyGhostRecord {
 }
 
 export interface DailyBoardData {
-  attemptUsed: boolean;
+  played: boolean; // already have a score on today's board (best-so-far)
   me: { rank: number; score: number } | null;
   streak: DailyStreak;
   total: number;
@@ -130,8 +132,10 @@ async function getStreak(fid: number): Promise<DailyStreak> {
 // ------------------------------------------------------------------- submit
 
 /**
- * Record the player's ONE counted run for the day. Board membership is the
- * attempt flag: a second submit returns alreadyPlayed without overwriting.
+ * Record one of the player's runs for the day. Tries are unlimited within the
+ * 24h window; only an improvement on their previous best overwrites the board
+ * score, profile, and rival ghost. Either way the play bumps the daily streak
+ * (idempotent per day) and we return the standing of their best score.
  */
 export async function submitDailyRun(
   day: string,
@@ -149,58 +153,56 @@ export async function submitDailyRun(
 
   if (redis) {
     const existing = await redis.zscore(boardKey(day), String(entry.fid));
-    if (existing !== null) {
-      const [rank, total, streak] = await Promise.all([
-        redis.zrevrank(boardKey(day), String(entry.fid)),
-        redis.zcard(boardKey(day)),
-        getStreak(entry.fid),
+    const prevBest = existing === null ? null : Number(existing);
+    const improved = prevBest === null || entry.score > prevBest;
+
+    if (improved) {
+      await redis.zadd(boardKey(day), {
+        score: entry.score,
+        member: String(entry.fid),
+      });
+      await Promise.all([
+        redis.expire(boardKey(day), BOARD_TTL),
+        redis.hset(playerKey(day, entry.fid), {
+          ...entry,
+          flair: entry.flair ?? "",
+          updatedAt: now,
+        }),
+        redis.expire(playerKey(day, entry.fid), BOARD_TTL),
+        ghost.samples.length >= 8
+          ? redis.set(ghostKey(day, entry.fid), JSON.stringify(ghost), {
+              ex: GHOST_TTL,
+            })
+          : Promise.resolve(),
       ]);
-      return { rank: (rank ?? 0) + 1, total, streak, alreadyPlayed: true };
     }
-    await redis.zadd(boardKey(day), {
-      score: entry.score,
-      member: String(entry.fid),
-    });
-    await Promise.all([
-      redis.expire(boardKey(day), BOARD_TTL),
-      redis.hset(playerKey(day, entry.fid), {
-        ...entry,
-        flair: entry.flair ?? "",
-        updatedAt: now,
-      }),
-      redis.expire(playerKey(day, entry.fid), BOARD_TTL),
-      ghost.samples.length >= 8
-        ? redis.set(ghostKey(day, entry.fid), JSON.stringify(ghost), {
-            ex: GHOST_TTL,
-          })
-        : Promise.resolve(),
-    ]);
     const [rank, total, streak] = await Promise.all([
       redis.zrevrank(boardKey(day), String(entry.fid)),
       redis.zcard(boardKey(day)),
       bumpStreak(entry.fid, day),
     ]);
-    return { rank: (rank ?? 0) + 1, total, streak, alreadyPlayed: false };
+    return {
+      rank: (rank ?? 0) + 1,
+      total,
+      streak,
+      improved,
+      best: improved ? entry.score : prevBest ?? entry.score,
+    };
   }
 
   const board = localBoard(day);
-  if (board.has(entry.fid)) {
-    const sorted = [...board.values()].sort((a, b) => b.score - a.score);
-    return {
-      rank: sorted.findIndex((e) => e.fid === entry.fid) + 1,
-      total: sorted.length,
-      streak: await getStreak(entry.fid),
-      alreadyPlayed: true,
-    };
-  }
-  board.set(entry.fid, { ...entry, updatedAt: now });
-  if (ghost.samples.length >= 8) {
-    let g = localGhosts.get(day);
-    if (!g) {
-      g = new Map();
-      localGhosts.set(day, g);
+  const prevBest = board.get(entry.fid)?.score ?? null;
+  const improved = prevBest === null || entry.score > prevBest;
+  if (improved) {
+    board.set(entry.fid, { ...entry, updatedAt: now });
+    if (ghost.samples.length >= 8) {
+      let g = localGhosts.get(day);
+      if (!g) {
+        g = new Map();
+        localGhosts.set(day, g);
+      }
+      g.set(entry.fid, ghost);
     }
-    g.set(entry.fid, ghost);
   }
   const streak = await bumpStreak(entry.fid, day);
   const sorted = [...board.values()].sort((a, b) => b.score - a.score);
@@ -208,7 +210,8 @@ export async function submitDailyRun(
     rank: sorted.findIndex((e) => e.fid === entry.fid) + 1,
     total: sorted.length,
     streak,
-    alreadyPlayed: false,
+    improved,
+    best: improved ? entry.score : prevBest ?? entry.score,
   };
 }
 
@@ -331,7 +334,7 @@ export async function getDailyBoard(
     }
 
     return {
-      attemptUsed: me !== null,
+      played: me !== null,
       me,
       streak: fid ? await getStreak(fid) : { count: 0, best: 0 },
       total,
@@ -373,7 +376,7 @@ export async function getDailyBoard(
     .filter((g): g is DailyGhostRecord => Boolean(g));
 
   return {
-    attemptUsed: me !== null,
+    played: me !== null,
     me,
     streak: fid ? await getStreak(fid) : { count: 0, best: 0 },
     total: sorted.length,

--- a/src/lib/skateShare.ts
+++ b/src/lib/skateShare.ts
@@ -149,6 +149,6 @@ export function buildDailyShareIntent({
   const shareUrl = `${baseShareUrl}?${params.toString()}`;
   return {
     shareUrl,
-    castText: `${opener}\n\nSame line for everyone, one counted shot a day. Beat me before it resets.\n\n${shareUrl}`,
+    castText: `${opener}\n\nSame line for everyone — run it all day, best score holds. Beat me before it resets.\n\n${shareUrl}`,
   };
 }


### PR DESCRIPTION
## Summary

The DAILY LINE shipped with a hard "one counted run a day" rule — once you played, every later run was an uncounted practice lap. Now you can run today's shared course as many times as you like inside the 24h window, and your **best** score is what holds your board rank. The recording of that best run becomes your rival ghost for everyone else chasing the line.

This turns the daily from a one-shot dare into a climb: a bad first run no longer locks you out for the day, and you can keep grinding to top yourself before the line resets.

## What changed

- **Keep-best submit.** `submitDailyRun` only overwrites the board score, player profile, and rival ghost when a run beats your previous best for the day. Lower runs are accepted but leave your standing intact. The old "board membership = attempt used" gate (and its `409 alreadyPlayed` response) is gone — every submit returns `200`.
- **Streaks unchanged in spirit.** Every play still bumps the daily streak, and `bumpStreak` stays idempotent per day, so replaying many times in one day counts as a single streak day.
- **Run classification.** On the daily, every run is now `counted` when the player can submit; `practice` is reserved for the can't-submit case (not signed in / not in the mini-app).
- **UI.** The menu standing chip reads **Best #rank of N** (and shows as soon as you have any score). The PLAY pill burns amber on every daily run with a "beat your best / best holds the board" caption, and the game-over screen calls out a **new daily best** vs **didn't top today's best (X)**.
- **Copy.** Share cast text, the dare OG image card, and the page metadata no longer say "one shot a day" — they now say "run it all day, best score holds."

## Notes

- `DailyBoardData.attemptUsed` → `played` and `DailySubmitResult` swaps `alreadyPlayed` for `{ improved, best }`; both the API route and client are updated in lockstep.
- Typecheck and lint are clean. Not yet exercised in the running UI — worth a quick manual pass on the daily flow (replay keeps the higher score, a new best updates the rank chip, streak only increments once across multiple runs) before/after merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8-D97757?logo=claude&logoColor=white)
