### PR TITLE
fix: use current token stakers endpoint

### DIFF
--- a/__tests__/api/token-stakers.test.ts
+++ b/__tests__/api/token-stakers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { GET } from "@/src/app/api/token/[tokenAddress]/stakers/route";
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+describe("/api/token/[tokenAddress]/stakers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("proxies to the token-specific stakers endpoint and preserves cache busting", async () => {
+    const stakers = [
+      {
+        holder_address: "0x70a02ba51b4af58e659ee9b4a8edd3b831d0240c",
+        staked_balance: 1182795470.5456154,
+        isStaker: true,
+      },
+    ];
+
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(stakers),
+    } as Response);
+
+    const request = new Request(
+      "http://localhost:3000/api/token/0x02c910f37f98ae7338bae8ce0a54e8e15f4a9f3b/stakers?v=123"
+    );
+    const response = await GET(request, {
+      params: Promise.resolve({
+        tokenAddress: "0x02c910f37f98ae7338bae8ce0a54e8e15f4a9f3b",
+      }),
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.streme.fun/api/token/0x02c910f37f98ae7338bae8ce0a54e8e15f4a9f3b/stakers?v=123",
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Streme/1.0",
+        },
+      }
+    );
+    await expect(response.json()).resolves.toEqual(stakers);
+  });
+});

--- a/__tests__/lib/tokenStakers.test.ts
+++ b/__tests__/lib/tokenStakers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "@jest/globals";
+import { normalizeTokenStakers } from "@/src/lib/tokenStakers";
+
+describe("normalizeTokenStakers", () => {
+  it("maps token-specific staker API rows to the leaderboard shape", () => {
+    expect(
+      normalizeTokenStakers([
+        {
+          holder_address: "0x70a02ba51b4af58e659ee9b4a8edd3b831d0240c",
+          staked_balance: 1182795470.5456154,
+          isStaker: true,
+          lastUpdated: { _seconds: 1781459816, _nanoseconds: 388000000 },
+          farcaster: {
+            fid: 354795,
+            username: "aaronv.eth",
+            pfp_url:
+              "https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/5a1cdc5e-860b-4c94-09ab-2fde995bc500/original",
+          },
+        },
+        {
+          holder_address: "0x045acd980764824b9eb6f312f0a2cdd9f3183503",
+          staked_balance: 0,
+          isStaker: false,
+        },
+      ])
+    ).toEqual([
+      {
+        address: "0x70a02ba51b4af58e659ee9b4a8edd3b831d0240c",
+        units: "1182795470.5456154",
+        percentage: 0,
+        isConnected: true,
+        fid: 354795,
+        username: "aaronv.eth",
+        display_name: "aaronv.eth",
+        pfp_url:
+          "https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw/5a1cdc5e-860b-4c94-09ab-2fde995bc500/original",
+        createdAtTimestamp: "1781459816",
+      },
+    ]);
+  });
+
+  it("keeps the older flattened staker rows working", () => {
+    expect(
+      normalizeTokenStakers([
+        {
+          address: "0x1b1c7b8a93fcdf9145065ba3f1c9facbaa0b987f",
+          units: "36791127",
+          percentage: 0.12,
+          isConnected: true,
+          fid: 123,
+          username: "malbek.eth",
+          pfp_url: null,
+        },
+      ])
+    ).toEqual([
+      {
+        address: "0x1b1c7b8a93fcdf9145065ba3f1c9facbaa0b987f",
+        units: "36791127",
+        percentage: 0.12,
+        isConnected: true,
+        fid: 123,
+        username: "malbek.eth",
+        display_name: undefined,
+        pfp_url: null,
+        createdAtTimestamp: "0",
+      },
+    ]);
+  });
+});

--- a/src/app/api/token/[tokenAddress]/stakers/route.ts
+++ b/src/app/api/token/[tokenAddress]/stakers/route.ts
@@ -17,7 +17,9 @@ export async function GET(
     const cacheParam = url.searchParams.get('v');
 
     // Build API URL with cache-busting parameter
-    const apiUrl = new URL(`https://api.streme.fun/api/stakers/${tokenAddress}`);
+    const apiUrl = new URL(
+      `https://api.streme.fun/api/token/${tokenAddress}/stakers`
+    );
     if (cacheParam) {
       apiUrl.searchParams.set('v', cacheParam);
     }

--- a/src/components/StakerLeaderboard.tsx
+++ b/src/components/StakerLeaderboard.tsx
@@ -3,16 +3,10 @@
 import { useState, useEffect } from "react";
 import { Modal } from "./Modal";
 import { toast } from "sonner";
-
-interface TokenStaker {
-  address: string;
-  units: string;
-  percentage: number;
-  isConnected: boolean;
-  fid?: number;
-  username?: string;
-  pfp_url?: string | null;
-}
+import {
+  normalizeTokenStakers,
+  type TokenStaker,
+} from "@/src/lib/tokenStakers";
 
 interface StakerLeaderboardProps {
   stakingPoolAddress: string;
@@ -60,7 +54,7 @@ export function StakerLeaderboard({
         throw new Error(`Failed to fetch stakers: ${response.statusText}`);
       }
 
-      const stakersData: TokenStaker[] = await response.json();
+      const stakersData = normalizeTokenStakers(await response.json());
 
       console.log(`Fetched ${stakersData.length} stakers for token ${tokenAddress}`);
 

--- a/src/components/StakerLeaderboardEmbed.tsx
+++ b/src/components/StakerLeaderboardEmbed.tsx
@@ -11,16 +11,10 @@ import sdk from "@farcaster/miniapp-sdk";
 import { useWalletAddressChange } from "@/src/hooks/useWalletSync";
 import { ZAP_CONTRACT_ADDRESS } from "@/src/lib/contracts";
 import { encodeZapData } from "@/src/lib/abiEncoding";
-
-interface TokenStaker {
-  address: string;
-  units: string;
-  percentage: number;
-  isConnected: boolean;
-  fid?: number;
-  username?: string;
-  pfp_url?: string | null;
-}
+import {
+  normalizeTokenStakers,
+  type TokenStaker,
+} from "@/src/lib/tokenStakers";
 
 interface StakerLeaderboardEmbedProps {
   stakingPoolAddress: string;
@@ -89,13 +83,16 @@ export function StakerLeaderboardEmbed({
         throw new Error(`Failed to fetch stakers: ${response.statusText}`);
       }
 
-      const stakersData: TokenStaker[] = await response.json();
+      const stakersData = normalizeTokenStakers(await response.json());
 
       // Filter out specific excluded address and take top 10
       const filteredStakers = stakersData
         .filter(
           (staker) =>
             staker.address.toLowerCase() !== "0xc749105bc4b4ea6285dbbe2e8221c922bea07a9d"
+        )
+        .sort(
+          (a, b) => Number.parseFloat(b.units) - Number.parseFloat(a.units)
         )
         .slice(0, 10);
 

--- a/src/lib/tokenStakers.ts
+++ b/src/lib/tokenStakers.ts
@@ -1,0 +1,91 @@
+export interface TokenStaker {
+  address: string;
+  units: string;
+  percentage: number;
+  isConnected: boolean;
+  fid?: number;
+  username?: string;
+  display_name?: string;
+  pfp_url?: string | null;
+  createdAtTimestamp?: string;
+}
+
+interface FarcasterUser {
+  fid?: number;
+  username?: string;
+  display_name?: string;
+  pfp_url?: string | null;
+}
+
+interface RawTokenStaker {
+  account?: string | { id?: string };
+  address?: string;
+  holder_address?: string;
+  units?: string;
+  balance?: string;
+  staked_balance?: number;
+  percentage?: number;
+  isConnected?: boolean;
+  isStaker?: boolean;
+  createdAtTimestamp?: string;
+  timestamp?: string;
+  lastUpdated?: {
+    _seconds?: number;
+  };
+  farcaster?: FarcasterUser;
+  farcasterUser?: FarcasterUser;
+  fid?: number;
+  username?: string;
+  display_name?: string;
+  pfp_url?: string | null;
+  profileImage?: string | null;
+}
+
+export function normalizeTokenStakers(data: unknown): TokenStaker[] {
+  if (!Array.isArray(data)) return [];
+
+  return data
+    .map((item) => normalizeTokenStaker(item))
+    .filter((staker): staker is TokenStaker => staker !== null);
+}
+
+function normalizeTokenStaker(item: unknown): TokenStaker | null {
+  if (!item || typeof item !== "object") return null;
+
+  const staker = item as RawTokenStaker;
+  const accountAddress =
+    typeof staker.account === "string" ? staker.account : staker.account?.id;
+  const address = staker.address || staker.holder_address || accountAddress;
+
+  if (!address || staker.isStaker === false) return null;
+
+  const farcaster = staker.farcaster || staker.farcasterUser;
+  const units =
+    staker.units ??
+    (staker.staked_balance !== undefined
+      ? staker.staked_balance.toString()
+      : staker.balance ?? "0");
+  const pfpUrl =
+    farcaster?.pfp_url !== undefined
+      ? farcaster.pfp_url
+      : staker.pfp_url !== undefined
+        ? staker.pfp_url
+        : staker.profileImage;
+
+  return {
+    address,
+    units,
+    percentage: staker.percentage ?? 0,
+    isConnected: staker.isConnected ?? true,
+    fid: farcaster?.fid ?? staker.fid,
+    username: farcaster?.username ?? staker.username,
+    display_name:
+      farcaster?.display_name ?? staker.display_name ?? farcaster?.username,
+    pfp_url: pfpUrl,
+    createdAtTimestamp:
+      staker.createdAtTimestamp ??
+      staker.timestamp ??
+      staker.lastUpdated?._seconds?.toString() ??
+      "0",
+  };
+}


### PR DESCRIPTION
## Summary

Token pages now read top stakers from the current token-specific API, so recovered tokens no longer show wallets that already unstaked. The Vercel route had been proxying to `/api/stakers/:token`, which returns stale flattened pool data; it now proxies to `/api/token/:token/stakers` and the leaderboard normalizes that response shape. Existing flat staker rows remain supported for compatibility.

## Testing

- `npm test -- __tests__/api/token-stakers.test.ts __tests__/lib/tokenStakers.test.ts --runInBand`
- `npm run typecheck`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
