### PR TITLE
[codex] Fix Uniswap V4 token page handling

### DIFF
--- a/images.d.ts
+++ b/images.d.ts
@@ -1,0 +1,17 @@
+declare module "*.png" {
+  import type { StaticImageData } from "next/image";
+  const src: StaticImageData;
+  export default src;
+}
+
+declare module "*.webp" {
+  import type { StaticImageData } from "next/image";
+  const src: StaticImageData;
+  export default src;
+}
+
+declare module "*.svg" {
+  import type { StaticImageData } from "next/image";
+  const src: StaticImageData;
+  export default src;
+}

--- a/src/app/token/[address]/TokenActions.tsx
+++ b/src/app/token/[address]/TokenActions.tsx
@@ -19,7 +19,11 @@ import { parseEther, parseUnits } from "viem";
 import { useTokenBalance } from "@/src/hooks/useTokenData";
 import { useTokenData } from "@/src/contexts/TokenPageContext";
 import { useTokenPrice } from "@/src/hooks/useTokenPrice";
-import { isStakingDisabled } from "@/src/lib/tokenUtils";
+import {
+  getZapLpType,
+  isStakingDisabled,
+  supportsZapStake,
+} from "@/src/lib/tokenUtils";
 
 // Base USDC contract address
 const USDC_BASE_ADDRESS = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
@@ -774,7 +778,7 @@ export function TokenActions({
               className="mb-4"
               pair={token.pair}
               type={token.type}
-              poolAddress={token.pool_address}
+              poolAddress={token.pool_address ?? undefined}
             />
           )}
 
@@ -805,14 +809,18 @@ export function TokenActions({
               }`}
             />
           </div>
-          {/* Buy & Stake Button (only for buy direction) - Hidden for v2/v2aero tokens */}
-          {tradeDirection === "buy" && tradeCurrency !== "USDC" && stakingAddress && !isStakingDisabled(token.type, contractAddress) && (
+          {/* Buy & Stake Button (only for buy direction) */}
+          {tradeDirection === "buy" &&
+            tradeCurrency !== "USDC" &&
+            stakingAddress &&
+            supportsZapStake(token.type) &&
+            !isStakingDisabled(token.type, contractAddress) && (
             <ZapStakeButton
               tokenAddress={contractAddress as `0x${string}`}
               stakingAddress={stakingAddress as `0x${string}`}
               symbol={token.symbol}
               pair={token.pair}
-              lpType={(token.type === "v2aero" || token.type === "v2aeronew") ? "aero" : "uniswap"}
+              lpType={getZapLpType(token.type)}
               tokenType={token.type}
               onSuccess={() => {
                 refreshBalances();
@@ -829,7 +837,7 @@ export function TokenActions({
           )}
         </div>
         <div className="my-6 h-px bg-base-300" />
-        {/* Staking Actions - Hidden for v2/v2aero tokens */}
+        {/* Staking Actions */}
         {stakingAddress && !isStakingDisabled(token.type, contractAddress) && (
           <StakeButton
             tokenAddress={contractAddress as `0x${string}`}

--- a/src/app/token/[address]/TokenPageContent.tsx
+++ b/src/app/token/[address]/TokenPageContent.tsx
@@ -13,6 +13,7 @@ import { StakerLeaderboard } from "@/src/components/StakerLeaderboard";
 import { StakerLeaderboardEmbed } from "@/src/components/StakerLeaderboardEmbed";
 import { ClaimFeesButton } from "@/src/components/ClaimFeesButton";
 import { useTokenData } from "@/src/contexts/TokenPageContext";
+import { getZapLpType, isUniswapV4Token } from "@/src/lib/tokenUtils";
 
 export function TokenPageContent() {
   const [stakingUpdateTrigger, setStakingUpdateTrigger] = useState(0);
@@ -150,17 +151,25 @@ ${shareUrl}`;
     );
   }
 
-  const embedUrl =
+  const fallbackPoolAddress =
     pageAddress.toLowerCase() ===
     "0x1234567890123456789012345678901234567890".toLowerCase()
-      ? "https://www.geckoterminal.com/base/pools/0x1035ae3f87a91084c6c5084d0615cc6121c5e228?embed=1&info=0&swaps=1&grayscale=0&light_chart=0"
-      : `https://www.geckoterminal.com/base/pools/${token.pool_address}?embed=1&info=0&swaps=1&grayscale=0&light_chart=0`;
-
-  const smallEmbedUrl =
-    pageAddress.toLowerCase() ===
-    "0x1234567890123456789012345678901234567890".toLowerCase()
-      ? "https://www.geckoterminal.com/base/pools/0x1035ae3f87a91084c6c5084d0615cc6121c5e228?embed=1&info=0&swaps=0&grayscale=0&light_chart=0"
-      : `https://www.geckoterminal.com/base/pools/${token.pool_address}?embed=1&info=0&swaps=0&grayscale=0&light_chart=0`;
+      ? "0x1035ae3f87a91084c6c5084d0615cc6121c5e228"
+      : null;
+  const chartPoolAddress =
+    token.pool_address ||
+    (isUniswapV4Token(token.type)
+      ? token.pool_key || token.contract_address
+      : null) ||
+    fallbackPoolAddress;
+  const buildGeckoEmbedUrl = (swaps: boolean) =>
+    chartPoolAddress
+      ? `https://www.geckoterminal.com/base/pools/${chartPoolAddress}?embed=1&info=0&swaps=${
+          swaps ? 1 : 0
+        }&grayscale=0&light_chart=0`
+      : null;
+  const embedUrl = buildGeckoEmbedUrl(true);
+  const smallEmbedUrl = buildGeckoEmbedUrl(false);
 
   return (
     <div className="max-w-[1440px] mx-auto sm:px-6 mt-6 md:px-8 md:mt-0 md:pt-28 pb-12">
@@ -198,14 +207,16 @@ ${shareUrl}`;
           {/* Chart - Always directly below Token Info */}
           <div className="card bg-base-100 border border-black/[.1] dark:border-white/[.1] h-fit">
             <div className="card-body p-0 md:p-4">
-              <iframe
-                data-privy-ignore
-                title="GeckoTerminal Embed"
-                src={isMiniAppView ? smallEmbedUrl : embedUrl}
-                className="w-full h-[500px] lg:h-[800px] rounded-lg"
-                allow="clipboard-write"
-                allowFullScreen
-              />
+              {embedUrl && smallEmbedUrl ? (
+                <iframe
+                  data-privy-ignore
+                  title="GeckoTerminal Embed"
+                  src={isMiniAppView ? smallEmbedUrl : embedUrl}
+                  className="w-full h-[500px] lg:h-[800px] rounded-lg"
+                  allow="clipboard-write"
+                  allowFullScreen
+                />
+              ) : null}
             </div>
           </div>
         </div>
@@ -229,6 +240,9 @@ ${shareUrl}`;
               stakingPool={token.staking_pool}
               symbol={token.symbol}
               tokenAddress={token.contract_address}
+              tokenType={token.type}
+              pair={token.pair}
+              poolAddress={token.pool_address}
               tokenLaunchTime={
                 token.timestamp
                   ? new Date(
@@ -246,11 +260,7 @@ ${shareUrl}`;
               tokenAddress={token.contract_address}
               tokenSymbol={token.symbol}
               stakingAddress={token.staking_address}
-              lpType={
-                token.type === "v2aero" || token.type === "v2aeronew"
-                  ? "aero"
-                  : "uniswap"
-              }
+              lpType={getZapLpType(token.type)}
               onViewAll={() => setIsStakerLeaderboardOpen(true)}
               onStakingChange={handleStakingChange}
               tokenPrice={token.price}
@@ -271,6 +281,9 @@ ${shareUrl}`;
               stakingPool={token.staking_pool}
               symbol={token.symbol}
               tokenAddress={token.contract_address}
+              tokenType={token.type}
+              pair={token.pair}
+              poolAddress={token.pool_address}
               tokenLaunchTime={
                 token.timestamp
                   ? new Date(
@@ -288,6 +301,7 @@ ${shareUrl}`;
               tokenAddress={token.contract_address}
               tokenSymbol={token.symbol}
               stakingAddress={token.staking_address}
+              lpType={getZapLpType(token.type)}
               onViewAll={() => setIsStakerLeaderboardOpen(true)}
               onStakingChange={handleStakingChange}
               isMiniApp={isMiniAppView}

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -71,7 +71,8 @@ export interface LaunchedToken {
   };
   staking_pool: string;
   staking_address: string;
-  pool_address: string;
+  pool_address: string | null;
+  pool_key?: string | null;
   username: string;
   pfp_url: string;
   lastTraded: {

--- a/src/app/types/token.ts
+++ b/src/app/types/token.ts
@@ -7,12 +7,13 @@ export interface Token {
   name: string;
   symbol: string;
   img_url: string | null;
-  pool_address: string;
+  pool_address: string | null;
+  pool_key?: string | null;
   cast_hash: string;
   type: string;
   pair: string;
   chain_id: number;
-  metadata: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
   profileImage: string | null;
   pool_id: string;
   staking_pool: string;

--- a/src/components/LiquidityWarning.tsx
+++ b/src/components/LiquidityWarning.tsx
@@ -5,6 +5,7 @@ import {
   useTokenLiquidity,
   isLiquidityLow,
 } from "@/src/hooks/useTokenLiquidity";
+import { isAerodromeToken, isUniswapV4Token } from "@/src/lib/tokenUtils";
 
 interface LiquidityWarningProps {
   tokenAddress: string;
@@ -27,14 +28,17 @@ export const LiquidityWarning = ({
   type,
   poolAddress: providedPoolAddress,
 }: LiquidityWarningProps) => {
+  const shouldCheckLiquidity =
+    !isAerodromeToken(type) &&
+    !isUniswapV4Token(type) &&
+    (!pair || pair.toUpperCase() === "WETH");
   const { wethBalance, wethBalanceFormatted, poolAddress, isLoading, error } =
-    useTokenLiquidity(tokenAddress, providedPoolAddress);
+    useTokenLiquidity(
+      shouldCheckLiquidity ? tokenAddress : "",
+      shouldCheckLiquidity ? providedPoolAddress : undefined
+    );
 
-  // Don't show warning for Aerodrome pools or other non-Uniswap pool types
-  if (type && (type.toLowerCase() === "v2aero" || type.toLowerCase() === "v2aeronew")) return null;
-
-  // Don't show warning for non-WETH pairs (ETHx, etc.) since hook only checks WETH
-  if (pair && pair.toUpperCase() !== "WETH") return null;
+  if (!shouldCheckLiquidity) return null;
 
   // Don't show warning if still loading or if there's an error
   if (isLoading || error) return null;
@@ -110,14 +114,17 @@ export const InlineLiquidityWarning = ({
   type,
   poolAddress: providedPoolAddress,
 }: Omit<LiquidityWarningProps, "onDismiss">) => {
+  const shouldCheckLiquidity =
+    !isAerodromeToken(type) &&
+    !isUniswapV4Token(type) &&
+    (!pair || pair.toUpperCase() === "WETH");
   const { wethBalance, wethBalanceFormatted, isLoading, error } =
-    useTokenLiquidity(tokenAddress, providedPoolAddress);
+    useTokenLiquidity(
+      shouldCheckLiquidity ? tokenAddress : "",
+      shouldCheckLiquidity ? providedPoolAddress : undefined
+    );
 
-  // Don't show warning for Aerodrome pools or other non-Uniswap pool types
-  if (type && (type.toLowerCase() === "v2aero" || type.toLowerCase() === "v2aeronew")) return null;
-
-  // Don't show warning for non-WETH pairs (ETHx, etc.) since hook only checks WETH
-  if (pair && pair.toUpperCase() !== "WETH") return null;
+  if (!shouldCheckLiquidity) return null;
 
   if (isLoading || error) return null;
 

--- a/src/components/StakedBalance.tsx
+++ b/src/components/StakedBalance.tsx
@@ -10,6 +10,7 @@ import {
   useTokenLiquidity,
   isLiquidityLow,
 } from "@/src/hooks/useTokenLiquidity";
+import { isAerodromeToken, isUniswapV4Token } from "@/src/lib/tokenUtils";
 
 interface StakedBalanceProps {
   stakingAddress: string;
@@ -17,6 +18,9 @@ interface StakedBalanceProps {
   symbol: string;
   tokenAddress: string;
   tokenLaunchTime: string | number | Date;
+  tokenType?: string;
+  pair?: string;
+  poolAddress?: string | null;
 }
 
 interface PoolData {
@@ -33,6 +37,9 @@ export function StakedBalance({
   symbol,
   tokenAddress,
   tokenLaunchTime,
+  tokenType,
+  pair,
+  poolAddress,
 }: StakedBalanceProps) {
   const { address, isConnected } = useWallet();
   const [stakedBalance, setStakedBalance] = useState<bigint>(0n);
@@ -228,9 +235,18 @@ export function StakedBalance({
 
   // Price is now handled by useTokenPrice hook
 
-  // Use shared liquidity check (Uniswap V3 WETH reserves)
-  const { wethBalance } = useTokenLiquidity(tokenAddress);
-  const lowLiquidity = isLiquidityLow(wethBalance, tokenLaunchTime);
+  const shouldCheckLiquidity =
+    !isAerodromeToken(tokenType) &&
+    !isUniswapV4Token(tokenType) &&
+    (!pair || pair.toUpperCase() === "WETH");
+
+  // Use shared liquidity check for V3-style WETH reserve pools only.
+  const { wethBalance } = useTokenLiquidity(
+    shouldCheckLiquidity ? tokenAddress : "",
+    shouldCheckLiquidity ? poolAddress ?? undefined : undefined
+  );
+  const lowLiquidity =
+    shouldCheckLiquidity && isLiquidityLow(wethBalance, tokenLaunchTime);
 
   // Calculate memoized values before early return
   const receivedUsdValue = useMemo(() => {

--- a/src/components/StakerLeaderboardEmbed.tsx
+++ b/src/components/StakerLeaderboardEmbed.tsx
@@ -21,7 +21,7 @@ interface StakerLeaderboardEmbedProps {
   tokenAddress: string;
   tokenSymbol: string;
   stakingAddress?: string;
-  lpType?: "uniswap" | "aero";
+  lpType?: "uniswap" | "aero" | "uniswap-v4";
   onViewAll: () => void;
   onStakingChange?: () => void;
   isMiniApp?: boolean;
@@ -139,6 +139,10 @@ export function StakerLeaderboardEmbed({
       toast.error("Wallet not connected or staking address missing");
       return;
     }
+    if (lpType === "uniswap-v4") {
+      toast.error("Buy & Stake is not available for this pool type yet");
+      return;
+    }
 
     setIsZapStaking(true);
     const toastId = toast.loading("Buying and Staking amount for #1...");
@@ -207,15 +211,7 @@ export function StakerLeaderboardEmbed({
         address: quoterAddress as `0x${string}`,
         abi: quoterAbi,
         functionName: "quoteExactInputSingle",
-        args: [
-          {
-            tokenIn: WETH,
-            tokenOut: toHex(tokenAddress),
-            amountIn: amountInWei,
-            fee: 10000,
-            sqrtPriceLimitX96: 0n,
-          },
-        ],
+        args,
       })) as [bigint, bigint, number, bigint];
       const amountOut = quoteResult[0];
       const amountOutMin = amountOut - amountOut / 200n; // 0.5% slippage
@@ -546,7 +542,10 @@ export function StakerLeaderboardEmbed({
       )}
 
       {/* Become Top Staker Button */}
-      {stakingAddress && !isUserTopStaker() && effectiveIsConnected && (
+      {stakingAddress &&
+        lpType !== "uniswap-v4" &&
+        !isUserTopStaker() &&
+        effectiveIsConnected && (
         <div className="mt-3 pt-3 border-t border-base-300">
           <div className="text-center">
             <button

--- a/src/components/ZapStakeButton.tsx
+++ b/src/components/ZapStakeButton.tsx
@@ -17,7 +17,7 @@ import { ensureTxHash } from "@/src/lib/ensureTxHash";
 import { ZAP_CONTRACT_ADDRESS } from "@/src/lib/contracts";
 import {
   isStakingDisabled,
-  getStakingDisabledMessage,
+  supportsZapStake,
 } from "@/src/lib/tokenUtils";
 import { encodeZapData } from "@/src/lib/abiEncoding";
 
@@ -106,6 +106,10 @@ export function ZapStakeButton({
   const handleZapStake = async () => {
     if (!isValid || !currentAddress || !walletIsConnected) {
       toast.error("Wallet not connected or address missing");
+      return;
+    }
+    if (!supportsZapStake(tokenType) || lpType === "uniswap-v4") {
+      toast.error("Buy & Stake is not available for this pool type yet");
       return;
     }
     setIsLoading(true);
@@ -421,13 +425,16 @@ export function ZapStakeButton({
 
   // Check if staking is disabled for this token type or address
   const stakingDisabled = isStakingDisabled(tokenType, tokenAddress);
-  const disabledMessage = getStakingDisabledMessage(tokenType, tokenAddress);
+  const zapUnsupported =
+    !supportsZapStake(tokenType) || lpType === "uniswap-v4";
 
   return (
     <>
       <button
         onClick={handleZapStake}
-        disabled={disabled || isLoading || !isValid || stakingDisabled}
+        disabled={
+          disabled || isLoading || !isValid || stakingDisabled || zapUnsupported
+        }
         className={className}
       >
         {isLoading ? (

--- a/src/lib/tokenUtils.ts
+++ b/src/lib/tokenUtils.ts
@@ -38,6 +38,27 @@ export const isStakingDisabled = (
   return false;
 };
 
+export const isAerodromeToken = (tokenType?: string): boolean => {
+  const normalizedType = tokenType?.toLowerCase();
+  return normalizedType === "v2aero" || normalizedType === "v2aeronew";
+};
+
+export const isUniswapV4Token = (tokenType?: string): boolean => {
+  return tokenType?.toLowerCase() === "v4uni";
+};
+
+export type ZapLpType = "uniswap" | "aero" | "uniswap-v4";
+
+export const getZapLpType = (tokenType?: string): ZapLpType => {
+  if (isAerodromeToken(tokenType)) return "aero";
+  if (isUniswapV4Token(tokenType)) return "uniswap-v4";
+  return "uniswap";
+};
+
+export const supportsZapStake = (tokenType?: string): boolean => {
+  return !isUniswapV4Token(tokenType);
+};
+
 /**
  * Get user-facing message explaining why staking is disabled
  * @param tokenType - Token type


### PR DESCRIPTION
## Summary
- handle Uniswap V4 token payloads where `pool_address` is null and `pool_key` is present
- build GeckoTerminal embeds from the V4 `pool_key`, falling back to the token address path GeckoTerminal redirects correctly
- skip V3-only liquidity warnings and zap-stake flows for V4 tokens until a V4 quote/zap path exists
- add shared token-type helpers and static image module declarations for typecheck

## Root Cause
The token page assumed every non-Aero token had a Uniswap V3-style pool address and could use V3 reserve checks, GeckoTerminal pool embeds, and V3 quoter/zap flows. The first V4 token uses `type: v4uni`, has `pool_key`, and has `pool_address: null`, which broke those assumptions.

## Validation
- `npm run typecheck`
- `npm test -- --runTestsByPath __tests__/api/quote.test.ts __tests__/api/token-stakers.test.ts`
- `npm run build`
- local and preview `GET /token/0x1a339c38ae22726f1a4235bcecf8f12aebe4c5e8` returned `200`
- GeckoTerminal token-address embed returns `307` to the V4 pool key URL