### PR TITLE
fix: disable experimental daily drop frontend

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -26,6 +26,7 @@ import sdk from "@farcaster/miniapp-sdk";
 import { convertTypesenseTokenToToken, TypesenseToken } from "../lib/typesenseClient";
 import { VoteBanner } from "../components/VoteBanner";
 import { WarpletGobblerPromo } from "../components/WarpletGobblerPromo";
+import { CHECKIN_CONFIG } from "../constants/checkin";
 
 function App() {
   const [tokens, setTokens] = useState<Token[]>([]);
@@ -341,6 +342,10 @@ function App() {
 
   // Check checkin status when miniapp first opens (only after wallet is connected)
   useEffect(() => {
+    if (!CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED) {
+      return;
+    }
+
     const checkCheckinStatus = async () => {
       if (
         isMiniAppView &&
@@ -547,23 +552,27 @@ function App() {
           onSkip={handleSkipTutorial}
         /> */}
 
-        {/* Checkin Modal */}
-        <CheckinModal
-          isOpen={showCheckinModal}
-          onClose={handleCloseCheckinModal}
-          onCheckin={performCheckin}
-          isLoading={checkinLoading}
-          hasCheckedIn={hasCheckedIn}
-          hasStakedBalance={hasStakedBalance}
-        />
+        {CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED && (
+          <>
+            {/* Checkin Modal */}
+            <CheckinModal
+              isOpen={showCheckinModal}
+              onClose={handleCloseCheckinModal}
+              onCheckin={performCheckin}
+              isLoading={checkinLoading}
+              hasCheckedIn={hasCheckedIn}
+              hasStakedBalance={hasStakedBalance}
+            />
 
-        {/* Checkin Success Modal */}
-        <CheckinSuccessModal
-          isOpen={showSuccessModal}
-          onClose={closeSuccessModal}
-          totalCheckins={checkinData?.totalCheckins}
-          currentStreak={checkinData?.currentStreak}
-        />
+            {/* Checkin Success Modal */}
+            <CheckinSuccessModal
+              isOpen={showSuccessModal}
+              onClose={closeSuccessModal}
+              totalCheckins={checkinData?.totalCheckins}
+              currentStreak={checkinData?.currentStreak}
+            />
+          </>
+        )}
       </div>
     );
   }

--- a/src/constants/checkin.ts
+++ b/src/constants/checkin.ts
@@ -1,6 +1,7 @@
 // Checkin-related constants
 
 export const CHECKIN_CONFIG = {
+  EXPERIMENTAL_DAILY_DROP_ENABLED: false,
   AUTO_SHOW_DELAY: 1500, // ms
   DROP_AMOUNT: 1000, // staked STREME
 } as const;

--- a/src/hooks/useCheckin.ts
+++ b/src/hooks/useCheckin.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import sdk from "@farcaster/miniapp-sdk";
 import { toast } from "sonner";
+import { CHECKIN_CONFIG } from "../constants/checkin";
 
 export interface CheckinData {
   success: boolean;
@@ -38,6 +39,19 @@ export function useCheckin() {
   });
 
   const performCheckin = useCallback(async () => {
+    if (!CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED) {
+      const errorMessage = "Experimental daily drop is disabled";
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: errorMessage,
+        hasAttempted: true,
+        showCheckinModal: false,
+        showSuccessModal: false,
+      }));
+      throw new Error(errorMessage);
+    }
+
     setState((prev) => ({
       ...prev,
       isLoading: true,
@@ -108,6 +122,8 @@ export function useCheckin() {
 
   // Auto-checkin on mount
   const autoCheckin = useCallback(async () => {
+    if (!CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED) return;
+
     // Only auto-checkin if we haven't already attempted
     if (!state.hasAttempted && !state.isLoading) {
       try {
@@ -136,6 +152,8 @@ export function useCheckin() {
   }, []);
 
   const openCheckinModal = useCallback(() => {
+    if (!CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED) return;
+
     setState((prev) => ({ ...prev, showCheckinModal: true }));
   }, []);
 
@@ -149,6 +167,8 @@ export function useCheckin() {
   }, []);
 
   const showSuccessModalDebug = useCallback(() => {
+    if (!CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED) return;
+
     const fakeCheckinData: CheckinData = {
       success: true,
       fid: 446697,

--- a/src/hooks/useCheckinModal.ts
+++ b/src/hooks/useCheckinModal.ts
@@ -34,9 +34,10 @@ export function useCheckinModal({
     hasCheckedIn,
   } = useCheckin();
   
-  const { flowRate } = useStremeFlowRate();
   const { trackModalAutoShown, trackDebugButtonClicked } = useCheckinTracking();
   
+  const isDailyDropEnabled = CHECKIN_CONFIG.EXPERIMENTAL_DAILY_DROP_ENABLED;
+  const { flowRate } = useStremeFlowRate(isDailyDropEnabled);
   const hasStakedBalance = flowRate !== "0" && flowRate !== undefined;
   
   // Custom close handler that remembers dismissal
@@ -47,13 +48,21 @@ export function useCheckinModal({
   
   // Handle debug button click
   const handleDebugButtonClick = useCallback(() => {
+    if (!isDailyDropEnabled) return;
+
     trackDebugButtonClicked(hasStakedBalance);
     openCheckinModal();
-  }, [hasStakedBalance, openCheckinModal, trackDebugButtonClicked]);
+  }, [
+    hasStakedBalance,
+    isDailyDropEnabled,
+    openCheckinModal,
+    trackDebugButtonClicked,
+  ]);
   
   // Auto-show checkin modal for eligible users
   useEffect(() => {
     const shouldAutoShow = 
+      isDailyDropEnabled &&
       isMiniAppView &&
       isConnected &&
       isOnCorrectNetwork &&
@@ -73,6 +82,7 @@ export function useCheckinModal({
     }
   }, [
     isMiniAppView,
+    isDailyDropEnabled,
     isConnected,
     isOnCorrectNetwork,
     hasCheckedIn,
@@ -90,9 +100,9 @@ export function useCheckinModal({
     checkinData,
     checkinError,
     checkinLoading,
-    showSuccessModal,
-    showCheckinModal,
-    hasCheckedIn,
+    showSuccessModal: isDailyDropEnabled && showSuccessModal,
+    showCheckinModal: isDailyDropEnabled && showCheckinModal,
+    hasCheckedIn: isDailyDropEnabled ? hasCheckedIn : true,
     hasStakedBalance,
     
     // Actions

--- a/src/hooks/useStremeFlowRate.ts
+++ b/src/hooks/useStremeFlowRate.ts
@@ -21,7 +21,7 @@ interface AccountTokenSnapshot {
   updatedAtTimestamp: string;
 }
 
-export function useStremeFlowRate() {
+export function useStremeFlowRate(enabled = true) {
   const { address: wagmiAddress } = useAccount();
   const { isMiniAppView, address: fcAddress } = useAppFrameLogic();
   const [flowRate, setFlowRate] = useState<string>("0");
@@ -31,7 +31,7 @@ export function useStremeFlowRate() {
   const effectiveAddress = isMiniAppView ? fcAddress : wagmiAddress;
 
   const fetchFlowRate = async () => {
-    if (!effectiveAddress) {
+    if (!enabled || !effectiveAddress) {
       // No need to log - this is a normal state when not connected
       return;
     }
@@ -180,8 +180,14 @@ export function useStremeFlowRate() {
   };
 
   useEffect(() => {
+    if (!enabled) {
+      setFlowRate("0");
+      setIsLoading(false);
+      return;
+    }
+
     fetchFlowRate();
-  }, [effectiveAddress]);
+  }, [effectiveAddress, enabled]);
 
   // Return the fetch function so it can be called manually
   return { flowRate, isLoading, refetch: fetchFlowRate };


### PR DESCRIPTION
## Summary

The miniapp no longer surfaces or triggers the experimental daily drop from the frontend. The check-in status poll, claim modal, debug opener, claim POST path, and check-in-specific flow-rate fetch now stay behind a disabled frontend flag, while backend scheduled drop behavior is unchanged.

## Validation

- `npm run typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
