### PR TITLE
fix: disable Snapshot vote banner

### DIFF
--- a/src/lib/snapshotConfig.ts
+++ b/src/lib/snapshotConfig.ts
@@ -3,7 +3,7 @@
 
 export const SNAPSHOT_CONFIG = {
   /** Set to true to show the vote banner in the mini app */
-  enabled: true,
+  enabled: false,
 
   /** Snapshot space (e.g. "superfluid.eth") */
   space: "superfluid.eth",


### PR DESCRIPTION
## Summary

The Snapshot voting banner is now hidden in the mini app, so users no longer see the "Vote for Streme" prompt or post-vote thank-you messaging while voting is paused.

## Validation

- `npm run typecheck`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a config-only UI visibility toggle; validate by opening the mini app and confirming the vote banner does not render for a connected mini-app user.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
